### PR TITLE
yaml: enable ivi-shell as a distro feature

### DIFF
--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -408,6 +408,11 @@ parameters:
         variables:
           XT_DOMA_TAG: "doma"
         components:
+          # Build and install ivi-shell in case of Android builds
+          domd:
+            builder:
+              conf:
+                - [DISTRO_FEATURES_append, " ivi-shell"]
           dom0:
             builder:
               additional_deps:


### PR DESCRIPTION
Enable and install ivi-shell as a distro feature
for doma build.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>