### PR TITLE
domd: Mask `aos-vis` if `vis` is not enabled

### DIFF
--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -539,6 +539,13 @@ parameters:
     desc: "Enable non open source aos-vis service"
     "no":
       default: true
+      overrides:
+        components:
+          domd:
+            builder:
+              conf:
+                # Mask aos-vis append
+                - [BBMASK_append, "|aos-vis"]
     "yes":
       overrides:
         components:


### PR DESCRIPTION
We have `aos-vis_git.bbappend` always present in the driver
domain in meta-xt-common. But `aos-vis.bb` from `meta-aos`
layer is present only when `vis` distro-feature is enabled.
So we need to mask out our bbappend when corresponding
receipt is not used.

Fixes: 1d2a6ddfc0cdc7cbd31df449f80f60763e66f881
