### PR TITLE
[New ATF recipe] yaml: KF: Mask other's ATF recipes

### DIFF
--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -93,6 +93,9 @@ common_data:
     # HACK: force ipk instead of rpm b/c it makes troubles to PVR UM build otherwise
     - [PACKAGE_CLASSES, "package_ipk"]
 
+    # Ignore ATF as we have own ATF recipe
+    - [BBMASK_append, "|meta-rcar-gen3/recipes-bsp/arm-trusted-firmware"]
+
   # The same set of layers and configs is used both in DomD and DomU
   # to build a DDK from source code
   ddk_source_overrides: &DDK_SOURCE_OVERRIDES
@@ -413,6 +416,8 @@ parameters:
               conf:
                 # Ignore OP-TEE patches as we have own OP-TEE
                 -  [BBMASK_append, "|meta-rcar-gen3-adas/recipes-bsp/optee"]
+                # Ignore ATF patches as we do not need V3 support
+                -  [BBMASK_append, "|meta-rcar-gen3-adas/recipes-bsp/arm-trusted-firmware"]
     h3ulcb-4x2g-ab:
       overrides:
         variables:


### PR DESCRIPTION
This commit masks
 - Renesas' arm-trusted-firmware.bb
 - Cogent's append to Renesas' recipe

We have few reasons to do so:
 - We re-implemented generation of binaries
   for different memory variants
 - We do not need support for V3* SOCs

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>