### PR TITLE
yaml: add pulseaudio to DomD & DomU distro_features

### DIFF
--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -90,6 +90,8 @@ common_data:
     # Remove ptest to reduce the build time
     - [DISTRO_FEATURES_remove, "ptest"]
 
+    - [DISTRO_FEATURES_append, " pulseaudio"]
+
     # HACK: force ipk instead of rpm b/c it makes troubles to PVR UM build otherwise
     - [PACKAGE_CLASSES, "package_ipk"]
 


### PR DESCRIPTION
Add pulseaudio to DISTRO_FEATURES for the domains.
This was done to enhance the configuration of the packages, that depends
from pulseaudio, such as sndbe.

Signed-off-by: Oleksii Moisieiev <oleksii_moisieiev@epam.com>