### PR TITLE
doma: introduce options for prebuilt graphics

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ optional arguments:
                         Build Android as a guest VM
   --ENABLE_DOMU {no,yes}
                         Build generic Yocto-based DomU
+  --ANDROID_PREBUILT_DDK {no,yes}
+                        Use pre-built GPU drivers for Android
 ```
 
 To built for Salvator XS M3 8GB with DomU (generic yocto-based virtual
@@ -107,6 +109,68 @@ command line: `moulin prod-devel-rcar.yaml --MACHINE
 salvator-xs-h3-4x2g --ENABLE_DOMU no --ENABLE_ANDROID yes `.
 
 This will require even more time and space, as Android is quite big.
+
+## Building with prebuilts Android graphics
+
+Prior to running ninja, you need to create "eva" directory (in product root, where the actual
+yaml file is present) and place Android prebuilds inside. So directory tree will be:
+```
+./eva
+├── pvr-km
+│   └── pvrsrvkm.ko
+└── pvr-um
+    └── r8a7795
+        ├── prebuilds.mk
+        └── vendor
+            ├── bin
+            │   ├── hwperfbin2jsont
+            │   ├── pvrhwperf
+            │   ├── pvrlogdump
+            │   ├── pvrlogsplit
+            │   ├── pvrsrvctl
+            │   └── rscompiler
+            ├── etc
+            │   ├── firmware
+            │   │   ├── rgx.fw.4.46.6.62
+            │   │   └── rgx.fw.4.46.6.62.vz
+            │   └── powervr.ini
+            ├── lib
+            │   ├── egl
+            │   │   ├── libEGL_POWERVR_ROGUE.so
+            │   │   ├── libGLESv1_CM_POWERVR_ROGUE.so
+            │   │   └── libGLESv2_POWERVR_ROGUE.so
+            │   ├── hw
+            │   │   ├── gralloc.r8a7795.so
+            │   │   ├── memtrack.r8a7795.so
+            │   │   └── vulkan.r8a7795.so
+            │   ├── libAppHintsIPC.so
+            │   ├── libglslcompiler.so
+            │   ├── libIMGegl.so
+            │   ├── libPVRRS.so
+            │   ├── libPVRScopeServices.so
+            │   ├── libsrv_um.so
+            │   ├── libufwriter.so
+            │   ├── libusc.so
+            │   └── vendor.imagination.gpu.apphints@1.0.so
+            └── lib64
+                ├── egl
+                │   ├── libEGL_POWERVR_ROGUE.so
+                │   ├── libGLESv1_CM_POWERVR_ROGUE.so
+                │   └── libGLESv2_POWERVR_ROGUE.so
+                ├── hw
+                │   ├── gralloc.r8a7795.so
+                │   ├── memtrack.r8a7795.so
+                │   └── vulkan.r8a7795.so
+                ├── libAppHintsIPC.so
+                ├── libglslcompiler.so
+                ├── libIMGegl.so
+                ├── libPVRRS.so
+                ├── libPVRScopeServices.so
+                ├── libsrv_um.so
+                ├── libufwriter.so
+                ├── libusc.so
+                └── vendor.imagination.gpu.apphints@1.0.so
+```
 
 ## Creating SD card image
 

--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -14,6 +14,9 @@ variables:
   XT_OP_TEE_FLAVOUR: "generic_dt"
   XT_GENERIC_DOMU_TAG: ""
   XT_DOMA_TAG: ""
+  XT_DOMA_DDK_KM_PREBUILT_MODULE: ""
+  XT_DOMA_KERNEL_EXTRA_MODULES: ""
+  XT_DOMA_SOURCE_GROUP: ""
 common_data:
   # Sources used by all yocto-based domains
   sources: &COMMON_SOURCES
@@ -266,7 +269,7 @@ components:
         rev: common-android12-5.4-xt-master
         manifest: default.xml
         depth: 1
-        groups: all
+        groups: "%{XT_DOMA_SOURCE_GROUP}"
         dir: "."
     builder:
       type: android_kernel
@@ -274,6 +277,7 @@ components:
         - "TARGET_BOARD_PLATFORM=%{SOC_FAMILY}"
         - "BUILD_CONFIG=common/build.config.xenvm"
         - "SKIP_MRPROPER=1"
+        - "EXT_MODULES=%{XT_DOMA_KERNEL_EXTRA_MODULES}"
       target_images:
         - "out/android12-5.4/common/arch/arm64/boot/Image"
         - "out/android12-5.4/staging/vendor/lib/modules/pvrsrvkm.ko"
@@ -286,14 +290,14 @@ components:
         rev: android-12-master
         manifest: doma.xml
         depth: 1
-        groups: all
+        groups: "%{XT_DOMA_SOURCE_GROUP}"
         dir: "."
     builder:
       type: android
       env:
         - "TARGET_BOARD_PLATFORM=%{SOC_FAMILY}"
         - "TARGET_PREBUILT_KERNEL=../android_kernel/out/android12-5.4/common/arch/arm64/boot/Image"
-        - "DDK_KM_PREBUILT_MODULE=../android_kernel/out/android12-5.4/staging/vendor/lib/modules/pvrsrvkm.ko"
+        - "DDK_KM_PREBUILT_MODULE=%{XT_DOMA_DDK_KM_PREBUILT_MODULE}"
       lunch_target: xenvm-userdebug
       target_images:
         - "out/target/product/xenvm/boot.img"
@@ -602,3 +606,23 @@ parameters:
             *DDK_SOURCE_OVERRIDES
           domu:
             *DDK_SOURCE_OVERRIDES
+  ANDROID_PREBUILT_DDK:
+    desc: "Use pre-built GPU drivers for Android"
+    "no":
+      default: true
+      overrides:
+        variables:
+          XT_DOMA_DDK_KM_PREBUILT_MODULE: "../android_kernel/out/android12-5.4/staging/vendor/lib/modules/pvrsrvkm.ko"
+          XT_DOMA_KERNEL_EXTRA_MODULES: "imagination"
+          XT_DOMA_SOURCE_GROUP: "all"
+    "yes":
+      overrides:
+        variables:
+          XT_DOMA_DDK_KM_PREBUILT_MODULE: "../eva/pvr-km/pvrsrvkm.ko"
+          XT_DOMA_KERNEL_EXTRA_MODULES: ""
+          XT_DOMA_SOURCE_GROUP: "default"
+        components:
+          doma:
+            builder:
+              env:
+                - "DDK_UM_PREBUILDS=../eva/pvr-um"


### PR DESCRIPTION
ANDROID_PREBUILT_DDK=yes will trigger the system
to not fetch closed source graphics and use prebuilt
binaries. Assuming that all prebuilt should be placed
into eva directory in the root of the product.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>