### PR TITLE
yaml: add unpacking support for doma graphics prebuilds

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,65 +112,9 @@ This will require even more time and space, as Android is quite big.
 
 ## Building with prebuilts Android graphics
 
-Prior to running ninja, you need to create "eva" directory (in product root, where the actual
-yaml file is present) and place Android prebuilds inside. So directory tree will be:
-```
-./eva
-├── pvr-km
-│   └── pvrsrvkm.ko
-└── pvr-um
-    └── r8a7795
-        ├── prebuilds.mk
-        └── vendor
-            ├── bin
-            │   ├── hwperfbin2jsont
-            │   ├── pvrhwperf
-            │   ├── pvrlogdump
-            │   ├── pvrlogsplit
-            │   ├── pvrsrvctl
-            │   └── rscompiler
-            ├── etc
-            │   ├── firmware
-            │   │   ├── rgx.fw.4.46.6.62
-            │   │   └── rgx.fw.4.46.6.62.vz
-            │   └── powervr.ini
-            ├── lib
-            │   ├── egl
-            │   │   ├── libEGL_POWERVR_ROGUE.so
-            │   │   ├── libGLESv1_CM_POWERVR_ROGUE.so
-            │   │   └── libGLESv2_POWERVR_ROGUE.so
-            │   ├── hw
-            │   │   ├── gralloc.r8a7795.so
-            │   │   ├── memtrack.r8a7795.so
-            │   │   └── vulkan.r8a7795.so
-            │   ├── libAppHintsIPC.so
-            │   ├── libglslcompiler.so
-            │   ├── libIMGegl.so
-            │   ├── libPVRRS.so
-            │   ├── libPVRScopeServices.so
-            │   ├── libsrv_um.so
-            │   ├── libufwriter.so
-            │   ├── libusc.so
-            │   └── vendor.imagination.gpu.apphints@1.0.so
-            └── lib64
-                ├── egl
-                │   ├── libEGL_POWERVR_ROGUE.so
-                │   ├── libGLESv1_CM_POWERVR_ROGUE.so
-                │   └── libGLESv2_POWERVR_ROGUE.so
-                ├── hw
-                │   ├── gralloc.r8a7795.so
-                │   ├── memtrack.r8a7795.so
-                │   └── vulkan.r8a7795.so
-                ├── libAppHintsIPC.so
-                ├── libglslcompiler.so
-                ├── libIMGegl.so
-                ├── libPVRRS.so
-                ├── libPVRScopeServices.so
-                ├── libsrv_um.so
-                ├── libufwriter.so
-                ├── libusc.so
-                └── vendor.imagination.gpu.apphints@1.0.so
-```
+Prior to running moulin, you need to place android graphics prebuilts
+archive `rcar-prebuilts-graphics-xt-doma.tar.gz` in the same directory
+as yaml file.
 
 ## Creating SD card image
 

--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -1,5 +1,5 @@
 desc: "Xen-Troops development setup for Renesas RCAR Gen3 hardware"
-min_ver: "0.6"
+min_ver: "0.7"
 
 variables:
   YOCTOS_WORK_DIR: "yocto"
@@ -618,11 +618,16 @@ parameters:
     "yes":
       overrides:
         variables:
-          XT_DOMA_DDK_KM_PREBUILT_MODULE: "../eva/pvr-km/pvrsrvkm.ko"
+          XT_DOMA_DDK_KM_PREBUILT_MODULE: "eva/pvr-km/pvrsrvkm.ko"
           XT_DOMA_KERNEL_EXTRA_MODULES: ""
           XT_DOMA_SOURCE_GROUP: "default"
         components:
           doma:
+            sources:
+              - type: unpack
+                file: rcar-prebuilts-graphics-xt-doma.tar.gz
+                dir: eva
+                archive_type: tar
             builder:
               env:
-                - "DDK_UM_PREBUILDS=../eva/pvr-um"
+                - "DDK_UM_PREBUILDS=eva/pvr-um"


### PR DESCRIPTION
Archive with graphics prebuilds(rcar-prebuilts-graphics-xt-doma.tar.gz)
should be placed in the same directory as yaml file.
The contents of that archive will be unpacked to the android/eva.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>