### PR TITLE
aos-vis related fixes

### DIFF
--- a/meta-aos-tune/recipes-aos/aos-vis/aos-vis_git.bbappend
+++ b/meta-aos-tune/recipes-aos/aos-vis/aos-vis_git.bbappend
@@ -36,7 +36,7 @@ do_prepare_adapters() {
     echo 'import (' >> ${file}
 
     for plugin in ${AOS_VIS_PLUGINS}; do
-        echo "\t_ \"aos_vis/plugins/${plugin}\"" >> ${file}
+        echo "\t_ \"${GO_IMPORT}/plugins/${plugin}\"" >> ${file}
     done
 
     echo ')' >> ${file}

--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -583,8 +583,8 @@ parameters:
           domd:
             sources:
               - type: git
-                url: "ssh://git@gitpct.epam.com/epmd-aepr/meta-aos"
-                rev: master
+                url: "https://github.com/aoscloud/meta-aos"
+                rev: main
             builder:
               layers:
                 - "../meta-aos"


### PR DESCRIPTION
- yaml: Switch meta-aos to a new repository
- aos-vis: 'go' import has wrong path 