### PR TITLE
yaml: Do not build ATF and optee-os in DomU 

### DIFF
--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -247,6 +247,8 @@ components:
         - *COMMON_CONF
         - *DOMD_DOMU_CONF
         - [XT_DOM_NAME, "domu"]
+        - [EXTRA_IMAGEDEPENDS_remove, "arm-trusted-firmware"]
+        - [EXTRA_IMAGEDEPENDS_remove, "optee-os"]
 
       layers:
         - "../meta-openembedded/meta-oe"


### PR DESCRIPTION
We do not need loaders (sa0, bl2, sa6, bl31) and tee in DomU.