### PR TITLE
Remove `h3ulcb` as not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Work is still in progress, but right now the following features are tested and w
 
 * Renesas Salvator-XS M3 with 8GB memory is supported
 * Renesas Salvator-X H3 with 8GB memory is supported
-* Renesas Starter Kit Premiere 8GB (H3ULCB)
+* Renesas Starter Kit Premiere 8GB (H3 ES3.0)
 * Kingfisher with Starter Kit Premiere 8GB board
 * AosBox with Starter Kit Premiere 8GB board
 * GPU sharing between domains
@@ -35,7 +35,7 @@ Features that are present but not tested:
 
 * Renesas Salvator-XS M3 with 4GB memory
 * Renesas Salvator-XS H3 with 8GB memory
-* Renesas Starter Kit Premiere (H3ULCB)
+* Renesas Starter Kit Premiere (H3 ES3.0 8GB)
 * Renesas Starter Kit Pro (M3ULCB)
 * Audio back-end
 

--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -416,17 +416,6 @@ parameters:
           XT_OP_TEE_FLAVOUR: "salvator_h3"
           XT_DOMD_DTB_NAME: "r8a7795-salvator-x-domd.dtb"
           XT_XEN_DTB_NAME: "r8a7795-salvator-x-xen.dtb"
-    h3ulcb:
-      overrides:
-        variables:
-          MACHINE: "h3ulcb"
-          SOC_FAMILY: "r8a7795"
-          XT_DOMD_CONFIG_NAME: "domd-h3ulcb.cfg"
-          XT_DOMU_CONFIG_NAME: "domu-generic-h3.cfg"
-          XT_DOMA_CONFIG_NAME: "doma-generic-h3.cfg"
-          XT_OP_TEE_FLAVOUR: "salvator_h3"
-          XT_DOMD_DTB_NAME: "r8a77951-h3ulcb-domd.dtb"
-          XT_XEN_DTB_NAME: "r8a77951-h3ulcb-xen.dtb"
     h3ulcb-4x2g:
       overrides:
         variables:


### PR DESCRIPTION
We support only StarterKit H3 ES3.0 8GB. And this machine is
described as `h3ulcb-4x2g` in our configuration.
This means that `h3ulcb` machine is for StarterKit H3 with 4GB.
But 4GB is supported only by ES2.0 SoC, which is not supported
by our product.