### PR TITLE
yaml: Fix usage of domz.cfg

### DIFF
--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -21,7 +21,8 @@ variables:
   XT_DOMA_KERNEL_EXTRA_MODULES: ""
   XT_DOMA_SOURCE_GROUP: ""
   XT_DOMZ_TAG: ""
-  XT_DOMZ_CONFIG_NAME: ""
+  # For this product we use one config for all machines for Zephyr
+  XT_DOMZ_CONFIG_NAME: "domz-generic.cfg"
   XT_MULTIMEDIA_EVA_DIR : ""
   XT_PREBUILT_GSX_DIR: ""
 common_data:
@@ -554,7 +555,6 @@ parameters:
       overrides:
         variables:
           XT_DOMZ_TAG: "domz"
-          XT_DOMZ_CONFIG_NAME: "domz-generic.cfg"
         components:
           dom0:
             builder:


### PR DESCRIPTION
Name of config for Zephyr is defined by variable `XT_DOMZ_CONFIG_NAME`.
This variable should always be defined for proper parsing of `domz.bb`.
For now we do not use machine specific configs for domz, so
we can define variable just once. But it can't be empty.

Fixes a75c6408fe784ee666c6c75cd0e507190b4512ce

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>