### PR TITLE
[Workaround] Use `meta-oe-fixups` to solve srecord issue

### DIFF
--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -223,6 +223,7 @@ components:
         - "../meta-openembedded/meta-filesystems"
         - "../meta-xt-common/meta-xt-domx"
         - "../meta-xt-common/meta-xt-driver-domain"
+        - "../meta-xt-rcar/meta-oe-fixups"
         - "../meta-xt-rcar/meta-xt-rcar-fixups"
         - "../meta-xt-rcar/meta-xt-rcar-driver-domain"
         - "../meta-xt-rcar/meta-xt-rcar-domx"


### PR DESCRIPTION
Add layers with workaround for incorrect libc used by srec_cat.
See comments inside `meta-oe-fixups` for details.

---
This PR is complimentary to https://github.com/xen-troops/meta-xt-rcar/pull/33