### PR TITLE
Set priority of layers to 12

### DIFF
--- a/meta-aos-tune/conf/layer.conf
+++ b/meta-aos-tune/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "aos-tune"
 BBFILE_PATTERN_aos-tune := "^${LAYERDIR}/"
-BBFILE_PRIORITY_aos-tune = "6"
+BBFILE_PRIORITY_aos-tune = "12"
 
 LAYERSERIES_COMPAT_aos-tune = "dunfell"
 

--- a/meta-xt-prod-devel-rcar-control/conf/layer.conf
+++ b/meta-xt-prod-devel-rcar-control/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "xt-prod-devel-rcar-control"
 BBFILE_PATTERN_xt-prod-devel-rcar-control := "^${LAYERDIR}/"
-BBFILE_PRIORITY_xt-prod-devel-rcar-control = "7"
+BBFILE_PRIORITY_xt-prod-devel-rcar-control = "12"
 
 LAYERSERIES_COMPAT_xt-prod-devel-rcar-control = "dunfell"
 

--- a/meta-xt-prod-devel-rcar-driver-domain/conf/layer.conf
+++ b/meta-xt-prod-devel-rcar-driver-domain/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "xt-prod-devel-driver-domain"
 BBFILE_PATTERN_xt-prod-devel-driver-domain := "^${LAYERDIR}/"
-BBFILE_PRIORITY_xt-prod-devel-driver-domain = "6"
+BBFILE_PRIORITY_xt-prod-devel-driver-domain = "12"
 
 LAYERSERIES_COMPAT_xt-prod-devel-driver-domain = "dunfell"
 


### PR DESCRIPTION
To make sure that specific components can override/redefine settings from more generic levels, we set the following priorities for levels:

```
meta-xt-common     -  8
meta-xt-<platform> - 10
meta-xt-<product>  - 12
```

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>