### PR TITLE
dom0/domd: Migrate to new Xen v4.17

### DIFF
--- a/meta-xt-domx-gen3/conf/layer.conf
+++ b/meta-xt-domx-gen3/conf/layer.conf
@@ -1,0 +1,13 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have a packages directory, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "xt-domx-gen3"
+BBFILE_PATTERN_xt-domx-gen3 := "^${LAYERDIR}/"
+BBFILE_PRIORITY_xt-domx-gen3 = "12"
+
+LAYERSERIES_COMPAT_xt-domx-gen3 = "dunfell"
+

--- a/meta-xt-domx-gen3/recipes-extended/xen/xen-source.inc
+++ b/meta-xt-domx-gen3/recipes-extended/xen/xen-source.inc
@@ -1,0 +1,4 @@
+LIC_FILES_CHKSUM = "file://COPYING;md5=d1a1e216f80b6d8da95fec897d0dbec9"
+
+SRC_URI = "git://github.com/xen-troops/xen.git;protocol=https;branch=xen-4.17-xt0.1"
+XEN_REL = "4.17"

--- a/meta-xt-domx-gen3/recipes-extended/xen/xen-tools_git.bbappend
+++ b/meta-xt-domx-gen3/recipes-extended/xen/xen-tools_git.bbappend
@@ -1,0 +1,29 @@
+require xen-source.inc
+
+PACKAGES_append = "\
+    ${PN}-test \
+"
+
+FILES_${PN}-test = "\
+    ${libdir}/xen/bin/test-xenstore \
+    ${libdir}/xen/bin/test-resource \
+    ${libdir}/xen/bin/test-paging-mempool\
+"
+
+RDEPENDS_${PN} += " \
+    util-linux-prlimit \
+"
+
+do_install_append() {
+    rm -f ${D}/${libdir}/xen/bin/init-dom0less
+    rm -f ${D}/${systemd_unitdir}/system/var-lib-xenstored.mount
+    rm -rf ${D}/var
+}
+
+FILES_${PN}-xencommons_remove = "\
+    "${systemd_unitdir}/system/var-lib-xenstored.mount" \
+"
+
+SYSTEMD_SERVICE_${PN}-xencommons_remove = " \
+    var-lib-xenstored.mount \
+"

--- a/meta-xt-domx-gen3/recipes-extended/xen/xen_git.bbappend
+++ b/meta-xt-domx-gen3/recipes-extended/xen/xen_git.bbappend
@@ -1,0 +1,1 @@
+require xen-source.inc

--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -172,6 +172,7 @@ components:
         - "../meta-xt-common/meta-xt-dom0"
         - "../meta-xt-common/meta-xt-control-domain"
         - "../meta-xt-rcar/meta-xt-rcar-dom0"
+        - "../meta-xt-prod-devel-rcar/meta-xt-domx-gen3"
         - "../meta-xt-prod-devel-rcar/meta-xt-prod-devel-rcar-control"
       build_target: core-image-thin-initramfs
       external_src:
@@ -228,6 +229,7 @@ components:
         - "../meta-xt-rcar/meta-xt-rcar-driver-domain"
         - "../meta-xt-rcar/meta-xt-rcar-domx"
         - "../meta-xt-rcar/meta-xt-rcar-gles_common"
+        - "../meta-xt-prod-devel-rcar/meta-xt-domx-gen3"
         - "../meta-xt-prod-devel-rcar/meta-xt-prod-devel-rcar-driver-domain"
       target_images:
         - "tmp/deploy/images/%{MACHINE}/Image"


### PR DESCRIPTION
For that purpose create a separate meta-xt-domx-gen3 sub-layer with appropriate xen/xen-tools recipes to perform v4.17 specific updates.

New Xen branch is at:
https://github.com/xen-troops/xen/commits/xen-4.17rc-migration

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>