### PR TITLE
domd-set-root: expand boot options

### DIFF
--- a/doc/u-boot-env.md
+++ b/doc/u-boot-env.md
@@ -33,7 +33,7 @@ setenv ethaddr 12:34:56:78:9A:BC
 ## TFTP boot
 ```
 setenv tftp_xen_load tftp 0x48080000 xen
-setenv tftp_dtb_load 'tftp 0x48000000 xen.dtb; fdt addr 0x48000000; fdt resize; fdt mknode / boot_dev; fdt set /boot_dev device nfs; fdt set /boot_dev my_ip ${ipaddr}; fdt set /boot_dev nfs_server_ip ${serverip}; fdt set /boot_dev nfs_dir "/srv/domd-YOUR_BOARD";'
+setenv tftp_dtb_load 'tftp 0x48000000 xen.dtb; fdt addr 0x48000000; fdt resize; fdt mknode / boot_dev; fdt set /boot_dev device nfs; fdt set /boot_dev my_ip ${ipaddr}; fdt set /boot_dev nfs_server_ip ${serverip}; fdt set /boot_dev nfs_dir "/srv/domd-YOUR_BOARD"; fdt set /boot_dev domu_nfs_dir "/srv/domu-YOUR_BOARD";'
 setenv tftp_kernel_load tftp 0x8a000000 Image
 setenv tftp_xenpolicy_load tftp 0x8c000000 xenpolicy
 setenv tftp_initramfs_load tftp 0x84000000 uInitramfs
@@ -46,7 +46,9 @@ IP address of this board
 #### nfs_server_ip
 IP address of a connected machine where NFS server is started
 #### nfs_dir
-Exported path of the root FS.
+Exported path of the root FS of DomD
+### domu_nfs_dir
+Exported path of the root FS of DomU
 
 ## SD0 card boot
 ```

--- a/doc/u-boot-env.md
+++ b/doc/u-boot-env.md
@@ -33,13 +33,20 @@ setenv ethaddr 12:34:56:78:9A:BC
 ## TFTP boot
 ```
 setenv tftp_xen_load tftp 0x48080000 xen
-setenv tftp_dtb_load 'tftp 0x48000000 xen.dtb; fdt addr 0x48000000; fdt resize; fdt mknode / boot_dev; fdt set /boot_dev device nfs'
+setenv tftp_dtb_load 'tftp 0x48000000 xen.dtb; fdt addr 0x48000000; fdt resize; fdt mknode / boot_dev; fdt set /boot_dev device nfs; fdt set /boot_dev my_ip ${ipaddr}; fdt set /boot_dev nfs_server_ip ${serverip}; fdt set /boot_dev nfs_dir "/srv/domd-YOUR_BOARD";'
 setenv tftp_kernel_load tftp 0x8a000000 Image
 setenv tftp_xenpolicy_load tftp 0x8c000000 xenpolicy
 setenv tftp_initramfs_load tftp 0x84000000 uInitramfs
 setenv bootcmd_tftp 'run tftp_xen_load; run tftp_dtb_load; run tftp_kernel_load; run tftp_xenpolicy_load; run tftp_initramfs_load; bootm 0x48080000 0x84000000 0x48000000'
 setenv bootcmd run bootcmd_tftp
 ```
+### NFS related properties in a device tree file
+#### my_ip
+IP address of this board
+#### nfs_server_ip
+IP address of a connected machine where NFS server is started
+#### nfs_dir
+Exported path of the root FS.
 
 ## SD0 card boot
 ```

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-set-root
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-set-root
@@ -12,7 +12,28 @@ fi
 
 # Special case for NFS - we want to quite different cmd line
 if [ $BOOT_STORAGE = nfs ] ; then
-    BOOT_STR="nfs nfsroot=192.168.1.100:\/srv\/domd,vers=3 ip=dhcp"
+    MY_IP=`cat /proc/device-tree/boot_dev/my_ip | tr -d '\000'`
+    if [ -z "$MY_IP" ] ; then
+        MY_IP="dhcp"
+        echo "WARNING! Using default ip address ${MY_IP}"
+    fi
+
+    SERVER_IP=`cat /proc/device-tree/boot_dev/nfs_server_ip  | tr -d '\000'`
+    if [ -z "$SERVER_IP" ] ; then
+        SERVER_IP="192.168.1.100"
+        echo "WARNING! Using default server ip address ${SERVER_IP}"
+    fi
+
+    NFS_DIR=`cat /proc/device-tree/boot_dev/nfs_dir | tr -d '\000'`
+    if [ -z "$NFS_DIR" ] ; then
+        NFS_DIR="/srv/domd"
+        echo "WARNING! Using default NFS directory ${NFS_DIR}"
+    fi
+
+    BOOT_STR="nfs nfsroot=${SERVER_IP}:${NFS_DIR},vers=3 ip=${MY_IP}"
+    # Escape slahes ( / ->\/ )
+    BOOT_STR=`echo "${BOOT_STR}" | sed "s/\//\\\\\\\\\//g"`
+
     echo "Mangling domain configuration: setting storage to network boot"
     sed -i "s/STORAGE_PART[0-9]/${BOOT_STR}/g" $DOMD_CFG_FILE
     exit 0

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domu/files/domu-set-root
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domu/files/domu-set-root
@@ -12,7 +12,22 @@ fi
 
 # Special case for NFS - we want to quite different cmd line
 if [ $BOOT_STORAGE = nfs ] ; then
-    BOOT_STR="nfs nfsroot=192.168.1.100:\/srv\/domu,vers=3 ip=dhcp"
+    SERVER_IP=`cat /proc/device-tree/boot_dev/nfs_server_ip  | tr -d '\000'`
+    if [ -z "$SERVER_IP" ] ; then
+        SERVER_IP="192.168.1.100"
+        echo "WARNING! Using default server ip address ${SERVER_IP}"
+    fi
+
+    NFS_DIR=`cat /proc/device-tree/boot_dev/domu_nfs_dir | tr -d '\000'`
+    if [ -z "$NFS_DIR" ] ; then
+        NFS_DIR="/srv/domu"
+        echo "WARNING! Using default NFS directory ${NFS_DIR}"
+    fi
+
+    BOOT_STR="nfs nfsroot=${SERVER_IP}:${NFS_DIR},vers=3 ip=dhcp"
+    # Escape slahes ( / ->\/ )
+    BOOT_STR=`echo "${BOOT_STR}" | sed "s/\//\\\\\\\\\//g"`
+
     echo "Mangling domain configuration: setting storage to network boot"
     sed -i "s/xvda1/${BOOT_STR}/" $DOMU_CFG_FILE
     sed -i "s/disk = /# disk = /" $DOMU_CFG_FILE


### PR DESCRIPTION
    changes are mostly based on commit
    65321202554d ("domd-set-root: expand boot options")
    from meta-xt-prod-devel-rcar-gen4 repository
    
    added changes to the ported commit:
        - changed setting of static ip to dhcp option;
        - moved property checks right after getting the property;
    
    updated TFTP boot section inside u-boot-env.md:
        - added description of how to set "nfs_server_ip", "my_ip"
        and "nfs_dir" properties in a device tree via "tftp_dtb_load"
        command;
    
Signed-off-by: Mykola Kvach <mykola_kvach@epam.com>

    changes are mostly based on commit
    82f3030bfe0b ("dom0: upgrade domu-set-root script")
    from meta-xt-prod-devel-rcar-gen4 repository
    
    added cosmetic changes to the ported commit:
        - moved property checks right after getting the property;
    
    updated TFTP boot section inside u-boot-env.md:
        - added description of how to set "domu_nfs_dir" property
          in a device tree via "tftp_dtb_load" command;
    
Signed-off-by: Mykola Kvach <mykola_kvach@epam.com>
