### PR TITLE
yaml: switch meta-xt-* layers to dunfell

### DIFF
--- a/prod-devel-rcar-agl.yaml
+++ b/prod-devel-rcar-agl.yaml
@@ -35,10 +35,10 @@ common_data:
       rev: dunfell
     - type: git
       url: "https://github.com/xen-troops/meta-xt-common.git"
-      rev: master
+      rev: dunfell
     - type: git
       url: "https://github.com/xen-troops/meta-xt-rcar.git"
-      rev: master
+      rev: dunfell
   # Common configuration options for all yocto-based domains
   conf: &COMMON_CONF
     - [SSTATE_DIR, "${TOPDIR}/../../../common_data/sstate"]
@@ -133,7 +133,7 @@ components:
       - *COMMON_SOURCES
       - type: git
         url: "https://github.com/xen-troops/meta-xt-prod-devel-rcar.git"
-        rev: master
+        rev: dunfell
     builder:
       type: yocto
       work_dir: "%{DOM0_BUILD_DIR}"
@@ -235,7 +235,7 @@ components:
         rev: dunfell
       - type: git
         url: "https://github.com/xen-troops/meta-xt-prod-devel-rcar.git"
-        rev: master
+        rev: dunfell
     builder:
       type: yocto
       work_dir: "%{DOMD_BUILD_DIR}"

--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -39,10 +39,10 @@ common_data:
       rev: dunfell
     - type: git
       url: "https://github.com/xen-troops/meta-xt-common.git"
-      rev: master
+      rev: dunfell
     - type: git
       url: "https://github.com/xen-troops/meta-xt-rcar.git"
-      rev: master
+      rev: dunfell
   # Common configuration options for all yocto-based domains
   conf: &COMMON_CONF
     - [SSTATE_DIR, "${TOPDIR}/../common_data/sstate"]
@@ -137,7 +137,7 @@ components:
       - *COMMON_SOURCES
       - type: git
         url: "https://github.com/xen-troops/meta-xt-prod-devel-rcar.git"
-        rev: master
+        rev: dunfell
     builder:
       type: yocto
       work_dir: "%{DOM0_BUILD_DIR}"
@@ -201,7 +201,7 @@ components:
         rev: dunfell
       - type: git
         url: "https://github.com/xen-troops/meta-xt-prod-devel-rcar.git"
-        rev: master
+        rev: dunfell
     builder:
       type: yocto
       work_dir: "%{DOMD_BUILD_DIR}"


### PR DESCRIPTION
We are moving to next Yocto release - Kirkstone. To preserve the current state of Xen Troops layers, we created "dunfell" branches before making transition to kirkstone. This is needed because not all products will be switched to kirkstone at once. It is expected that products that didn't made transition will use "dunfell" branch.

This patch goes into "dunfell" branch of meta-xt-prod-devel-rcar. It switches revisions from master to dunfell, so we can build dunfell-based version of prod-devel-rcar in case we need it.