### PR TITLE
weston-init: add specific ivi-shell settings

### DIFF
--- a/meta-xt-domx-gen3/recipes-graphics/wayland/weston-init.bbappend
+++ b/meta-xt-domx-gen3/recipes-graphics/wayland/weston-init.bbappend
@@ -1,0 +1,18 @@
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+do_install:append() {
+    if echo "${DISTRO_FEATURES}" | grep -q "ivi-shell"; then
+        sed -i '/\[core\]/c\\[core\]\nmodules=ivi-controller.so' \
+            ${D}/${sysconfdir}/xdg/weston/weston.ini
+        sed -e '$a\\' \
+            -e '$a\[ivi-shell]' \
+            -e '$a\ivi-id-agent-module=ivi-id-agent.so' \
+            -i ${D}/${sysconfdir}/xdg/weston/weston.ini
+        sed -e '$a\\' \
+            -e '$a\[desktop-app-default]' \
+            -e '$a\default-surface-id=2000000' \
+            -e '$a\default-surface-id-max=2001000' \
+            -i ${D}/${sysconfdir}/xdg/weston/weston.ini
+    fi
+}


### PR DESCRIPTION
weston-init: add specific ivi-shell settings

After the removal ivi-shell settings from meta-xt-common,
each product should provide its own settings with
respect to the needs.