### PR TITLE
distro-features: Add displbe & sndbe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # meta-xt-prod-devel-rcar #
 
+# Table of contents
+
+- [Overview](#overview)
+- [Moulin project file](#moulin-project-file)
+- [Building the project](#building-the-project)
+  - [Requirements](#requirements)
+  - [Fetching](#fetching)
+  - [Building](#building)
+  - [Building with prebuilt graphics for DomD+DomU](#building-with-prebuilt-graphics-for-domddomu)
+  - [Building with prebuilts Android graphics](#building-with-prebuilts-android-graphics)
+    - [Creating SD card image](#creating-sd-card-image)
+    - [Using rouge in standalone mode](#using-rouge-in-standalone-mode)
+  - [Distro features](#distro-features)
+
+# Overview
+
 This repository contains Renesas RCAR Gen3-specific Yocto layers for
 Xen Troops distro and `moulin` project file to build it. Layers in this
 repository provide final recipes to build meta-xt-prod-devel-rcar
@@ -39,7 +55,7 @@ Features that are present but not tested:
 * Renesas Starter Kit Pro (M3ULCB)
 * Audio back-end
 
-# Building
+# Building the project
 ## Requirements
 
 1. Ubuntu 18.0+ or any other Linux distribution which is supported by Poky/OE

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ usage: moulin prod-devel-rcar.yaml
        [--ENABLE_ZEPHYR {no,yes}] [--ENABLE_MM {no,yes}]
        [--ENABLE_AOS_VIS {no,yes}] [--PREBUILT_DDK {no,yes}]
        [--ANDROID_PREBUILT_DDK {no,yes}]
+       [--ENABLE_VIRTIO {no,yes}]
 
 Config file description: Xen-Troops development setup for Renesas RCAR Gen3
 hardware
@@ -97,6 +98,9 @@ optional arguments:
                         Use pre-built GPU drivers
   --ANDROID_PREBUILT_DDK {no,yes}
                         Use pre-built GPU drivers for Android
+  --ENABLE_VIRTIO {no,yes}
+                        Enable sharing of the devices between the driver and the guest domains,
+                        using the virtio technology ( work in progress )
 ```
 
 To build for Salvator XS M3 8GB with DomU (generic yocto-based virtual
@@ -227,7 +231,7 @@ For more information about `rouge` check its
 
 This repository introduces the following Yocto **DISTRO_FEATURES**. They are used, or not used, depending on the moulin build parameters.
 
-|Distro feature|Comment|
-|---|---|
-|displbe|Specifies whether to build and to install [this](https://github.com/xen-troops/displ_be) implementation as a 'displbe' systemd service.|
-|sndbe|Specifies whether to build and to install [this](https://github.com/xen-troops/snd_be) implementation as a 'sndbe' systemd service.|
+|Distro feature|Comment|Typical use-case|
+|---|---|---|
+|displbe|Specifies whether to build and to install [this](https://github.com/xen-troops/displ_be) implementation as a 'displbe' systemd service.|**NOT** used with the ENABLE_VIRTIO parameter|
+|sndbe|Specifies whether to build and to install [this](https://github.com/xen-troops/snd_be) implementation as a 'sndbe' systemd service.|**NOT** used with the ENABLE_VIRTIO parameter|

--- a/README.md
+++ b/README.md
@@ -222,3 +222,12 @@ option.
 
 For more information about `rouge` check its
 [manual](https://moulin.readthedocs.io/en/latest/rouge.html).
+
+# Distro features
+
+This repository introduces the following Yocto **DISTRO_FEATURES**. They are used, or not used, depending on the moulin build parameters.
+
+|Distro feature|Comment|
+|---|---|
+|displbe|Specifies whether to build and to install [this](https://github.com/xen-troops/displ_be) implementation as a 'displbe' systemd service.|
+|sndbe|Specifies whether to build and to install [this](https://github.com/xen-troops/snd_be) implementation as a 'sndbe' systemd service.|

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/doma/doma.bbappend
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/doma/doma.bbappend
@@ -6,13 +6,15 @@ SRC_URI += "\
     file://doma-vdevices.cfg \
     file://doma-set-root \
     file://doma-set-root.conf \
-    file://backends.conf \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'sndbe', 'file://sndbe-backend.conf', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'displbe', 'file://displbe-backend.conf', '', d)} \
 "
 
 FILES:${PN} += " \
     ${libdir}/xen/bin/doma-set-root \
     ${sysconfdir}/systemd/system/doma.service.d/doma-set-root.conf \
-    ${sysconfdir}/systemd/system/doma.service.d/backends.conf \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'sndbe', '${sysconfdir}/systemd/system/doma.service.d/sndbe-backend.conf', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'displbe', '${sysconfdir}/systemd/system/doma.service.d/displbe-backend.conf', '', d)} \
 "
 
 do_install:append() {
@@ -26,5 +28,12 @@ do_install:append() {
 
     # Install drop-in file to add dependencies on sndbe and displbe
     # Directory is installed above for doma-set-root.conf
-    install -m 0644 ${WORKDIR}/backends.conf ${D}${sysconfdir}/systemd/system/doma.service.d
+
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'sndbe', 'true', 'false', d)}; then
+        install -m 0644 ${WORKDIR}/sndbe-backend.conf ${D}${sysconfdir}/systemd/system/doma.service.d
+    fi
+
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'displbe', 'true', 'false', d)}; then
+        install -m 0644 ${WORKDIR}/displbe-backend.conf ${D}${sysconfdir}/systemd/system/doma.service.d
+    fi
 }

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/doma/files/backends.conf
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/doma/files/backends.conf
@@ -1,3 +1,0 @@
-[Unit]
-Requires=backend-ready@displbe.service backend-ready@sndbe.service
-After=backend-ready@displbe.service backend-ready@sndbe.service

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/doma/files/displbe-backend.conf
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/doma/files/displbe-backend.conf
@@ -1,0 +1,3 @@
+[Unit]
+Requires=backend-ready@displbe.service
+After=backend-ready@displbe.service

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/doma/files/sndbe-backend.conf
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/doma/files/sndbe-backend.conf
@@ -1,0 +1,3 @@
+[Unit]
+Requires=backend-ready@sndbe.service
+After=backend-ready@sndbe.service

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domu/domu.bbappend
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domu/domu.bbappend
@@ -5,10 +5,14 @@ SRC_URI += "\
     file://domu-vdevices.cfg \
     file://domu-pvcamera.cfg \
     file://domu-set-root \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'sndbe', 'file://sndbe-backend.conf', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'displbe', 'file://displbe-backend.conf', '', d)} \
 "
 
 FILES:${PN} += " \
     ${libdir}/xen/bin/domu-set-root \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'sndbe', '${sysconfdir}/systemd/system/domu.service.d/sndbe-backend.conf', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'displbe', '${sysconfdir}/systemd/system/domu.service.d/displbe-backend.conf', '', d)} \
 "
 
 # It is used a lot in the do_install, so variable will be handy
@@ -30,7 +34,7 @@ do_install:append() {
         # Update root by changing xvda1 to vda
         sed -i 's/root=\/dev\/xvda1/root=\/dev\/vda/' ${CFG_FILE}
 
-        # Update GUEST_DEPENDENCIES by adding virtio-disk after sndbe
+        # Update GUEST_DEPENDENCIES by adding dependency to the virtio
         echo "[Unit]" >> ${D}${systemd_unitdir}/system/domu.service
         echo "Requires=backend-ready@virtio.service" >> ${D}${systemd_unitdir}/system/domu.service
         echo "After=backend-ready@virtio.service" >> ${D}${systemd_unitdir}/system/domu.service
@@ -39,6 +43,14 @@ do_install:append() {
     # Install domu-set-root script
     install -d ${D}${libdir}/xen/bin
     install -m 0744 ${WORKDIR}/domu-set-root ${D}${libdir}/xen/bin
+
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'sndbe', 'true', 'false', d)}; then
+        install -m 0644 ${WORKDIR}/sndbe-backend.conf ${D}${sysconfdir}/systemd/system/domu.service.d
+    fi
+
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'displbe', 'true', 'false', d)}; then
+        install -m 0644 ${WORKDIR}/displbe-backend.conf ${D}${sysconfdir}/systemd/system/domu.service.d
+    fi
 
     # Call domu-set-root script
     echo "[Service]" >> ${D}${systemd_unitdir}/system/domu.service

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domu/files/displbe-backend.conf
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domu/files/displbe-backend.conf
@@ -1,0 +1,3 @@
+[Unit]
+Requires=backend-ready@displbe.service
+After=backend-ready@displbe.service

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domu/files/sndbe-backend.conf
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domu/files/sndbe-backend.conf
@@ -1,0 +1,3 @@
+[Unit]
+Requires=backend-ready@sndbe.service
+After=backend-ready@sndbe.service

--- a/meta-xt-prod-devel-rcar-driver-domain/recipes-graphics/images/core-image-weston.bbappend
+++ b/meta-xt-prod-devel-rcar-driver-domain/recipes-graphics/images/core-image-weston.bbappend
@@ -1,7 +1,8 @@
 IMAGE_INSTALL:append = " \
-    sndbe \
     ${@bb.utils.contains('DISTRO_FEATURES', 'pvcamera', 'camerabe', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'vis', 'aos-vis', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'sndbe', 'sndbe', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'displbe', 'displbe', '', d)} \
 "
 
 # We add 500 MB of free space for media content.

--- a/prod-devel-rcar-agl.yaml
+++ b/prod-devel-rcar-agl.yaml
@@ -768,3 +768,21 @@ parameters:
             builder:
               env:
                 - "DDK_UM_PREBUILDS=eva/pvr-um"
+
+  ENABLE_VIRTIO:
+    desc: "Enable sharing of the virtio devices from the driver domain to the guest domain"
+    "no":
+      default: true
+    "yes":
+      overrides:
+        components:
+          dom0:
+            builder:
+              conf:
+                # We do not need displbe & sndbe in case of virtio
+                - [DISTRO_FEATURES:remove, " displbe sndbe"]
+          domd:
+            builder:
+              conf:
+                # We do not need displbe & sndbe in case of virtio
+                - [DISTRO_FEATURES:remove, " displbe sndbe"]

--- a/prod-devel-rcar-agl.yaml
+++ b/prod-devel-rcar-agl.yaml
@@ -56,6 +56,9 @@ common_data:
     # Remove features that we are not using
     - [DISTRO_FEATURES_remove, "x11 gtk gobject-introspection-data wifi nfc bluetooth irda zeroconf 3g sysvinit"]
 
+    # displbe and sndbe
+    - [DISTRO_FEATURES:append, " displbe sndbe"]
+
   # Conf options for domain that are built used renesas layer
   domd_domu_conf: &DOMD_DOMU_CONF
     - [MACHINE, "%{MACHINE}"]

--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -746,3 +746,21 @@ parameters:
             builder:
               env:
                 - "DDK_UM_PREBUILDS=eva/pvr-um"
+
+  ENABLE_VIRTIO:
+    desc: "Enable sharing of the virtio devices from the driver domain to the guest domain"
+    "no":
+      default: true
+    "yes":
+      overrides:
+        components:
+          dom0:
+            builder:
+              conf:
+                # We do not need displbe & sndbe in case of virtio
+                - [DISTRO_FEATURES:remove, " displbe sndbe"]
+          domd:
+            builder:
+              conf:
+                # We do not need displbe & sndbe in case of virtio
+                - [DISTRO_FEATURES:remove, " displbe sndbe"]

--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -61,6 +61,9 @@ common_data:
     # Remove features that we are not using
     - [DISTRO_FEATURES:remove, "x11 gtk gobject-introspection-data wifi nfc bluetooth irda zeroconf 3g sysvinit"]
 
+    # displbe and sndbe
+    - [DISTRO_FEATURES:append, " displbe sndbe"]
+
   # Conf options for domain that are built used renesas layer
   domd_domu_conf: &DOMD_DOMU_CONF
     - [MACHINE, "%{MACHINE}"]


### PR DESCRIPTION
## distro-features: Add displbe & sndbe

In case of virtio functionality, we do not need installation of the
displbe and sndbe services. Driver domain should not install and
execute those services. Control domain should not have dependencies to
those services.

This patch is intended to introduce 'displbe' and 'sndbe' ditribution
features, which allow to turn mentioned services on and off for a
specific product.

## virtio: Introduce ENABLE_VIRTIO moulin parameter

We need a separate moulin parameter to implement builds with the virtio
devices sharing capabilities.

This patch adds first iteration of such a parameter. As of now, it does
only turn off the displbe and sndbe distro features.

## readme: Introduce table of contents

It is much easier to navigate over the documentation, when it has table
of contents. This patch creates such a table in the README.md