### PR TITLE
domd & doma: conditional Xen config RAM assignment

### DIFF
--- a/meta-xt-prod-devel-rcar-control/recipes-guests/doma/doma.bbappend
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/doma/doma.bbappend
@@ -17,7 +17,15 @@ FILES:${PN} += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'displbe', '${sysconfdir}/systemd/system/doma.service.d/displbe-backend.conf', '', d)} \
 "
 
+DOMA_RAM_SIZE:mem8gb:enable_android = "5120"
+DOMA_RAM_SIZE:mem8gb:enable_android:enable_virtio = "4096"
+
 do_install:append() {
+
+    echo "" >> ${D}${sysconfdir}/xen/doma.cfg
+    echo "# Initial memory allocation (MB)" >> ${D}${sysconfdir}/xen/doma.cfg
+    echo "memory = ${DOMA_RAM_SIZE}" >> ${D}${sysconfdir}/xen/doma.cfg
+
     cat ${WORKDIR}/doma-vdevices.cfg >> ${D}${sysconfdir}/xen/doma.cfg
 
     # Install doma-set-root script and the drop-in file to run it

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/doma/files/doma-generic-h3-4x2g.cfg
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/doma/files/doma-generic-h3-4x2g.cfg
@@ -32,9 +32,6 @@ dt_passthrough_nodes = [
 # Kernel command line options
 extra = "androidboot.boot_devices=51712 androidboot.hardware=xenvm init=/init ro rootwait console=hvc0 cma=256M@1-2G androidboot.selinux=permissive pvrsrvkm.DriverMode=1 androidboot.android_dt_dir=/proc/device-tree/firmware#1/android/ xt_page_pool=2097152 xt_cma=4194304"
 
-# Initial memory allocation (MB)
-memory = 5120
-
 # Number of VCPUS
 vcpus = 4
 

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/doma/files/doma-generic-m3-2x4g.cfg
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/doma/files/doma-generic-m3-2x4g.cfg
@@ -30,9 +30,6 @@ dt_passthrough_nodes = [
 # Kernel command line options
 extra = "androidboot.boot_devices=51712 androidboot.hardware=xenvm init=/init ro rootwait console=hvc0 cma=256M@1-2G androidboot.selinux=permissive pvrsrvkm.DriverMode=1 androidboot.android_dt_dir=/proc/device-tree/firmware#1/android/ xt_page_pool=2097152 xt_cma=4194304"
 
-# Initial memory allocation (MB)
-memory = 5120
-
 # Number of VCPUS
 vcpus = 4
 

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domd/domd.bbappend
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domd/domd.bbappend
@@ -8,7 +8,16 @@ FILES:${PN} += " \
     ${libdir}/xen/bin/domd-set-root \
 "
 
+DOMD_RAM_SIZE:mem8gb = "2048"
+DOMD_RAM_SIZE:mem4gb = "1024"
+DOMD_RAM_SIZE:mem8gb:enable_android:enable_virtio = "3072"
+
 do_install:append() {
+
+    echo "" >> ${D}${sysconfdir}/xen/domd.cfg
+    echo "# Initial memory allocation (MB)" >> ${D}${sysconfdir}/xen/domd.cfg
+    echo "memory = ${DOMD_RAM_SIZE}" >> ${D}${sysconfdir}/xen/domd.cfg
+
     # Install domd-set-root script
     install -d ${D}${libdir}/xen/bin
     install -m 0744 ${WORKDIR}/domd-set-root ${D}${libdir}/xen/bin

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-h3ulcb-4x2g-ab.cfg
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-h3ulcb-4x2g-ab.cfg
@@ -15,9 +15,6 @@ device_tree = "/usr/lib/xen/boot/domd.dtb"
 # Kernel command line options
 extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0"
 
-# Initial memory allocation (MB)
-memory = 2048
-
 # Number of VCPUS
 vcpus = 4
 

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-h3ulcb-4x2g-kf.cfg
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-h3ulcb-4x2g-kf.cfg
@@ -13,9 +13,6 @@ device_tree = "/usr/lib/xen/boot/domd.dtb"
 # Kernel command line options
 extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0"
 
-# Initial memory allocation (MB)
-memory = 2048
-
 # Number of VCPUS
 vcpus = 4
 

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-h3ulcb-4x2g.cfg
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-h3ulcb-4x2g.cfg
@@ -15,9 +15,6 @@ device_tree = "/usr/lib/xen/boot/domd.dtb"
 # Kernel command line options
 extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0"
 
-# Initial memory allocation (MB)
-memory = 2048
-
 # Number of VCPUS
 vcpus = 4
 

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-m3ulcb.cfg
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-m3ulcb.cfg
@@ -15,9 +15,6 @@ device_tree = "/usr/lib/xen/boot/domd.dtb"
 # Kernel command line options
 extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0"
 
-# Initial memory allocation (MB)
-memory = 1024
-
 # Number of VCPUS
 vcpus = 4
 

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-salvator-x-h3-4x2g.cfg
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-salvator-x-h3-4x2g.cfg
@@ -15,9 +15,6 @@ device_tree = "/usr/lib/xen/boot/domd.dtb"
 # Kernel command line options
 extra = "video=VGA-1:d video=LVDS-1:d root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0"
 
-# Initial memory allocation (MB)
-memory = 2048
-
 # Number of VCPUS
 vcpus = 4
 

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-salvator-x-m3.cfg
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-salvator-x-m3.cfg
@@ -15,9 +15,6 @@ device_tree = "/usr/lib/xen/boot/domd.dtb"
 # Kernel command line options
 extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0"
 
-# Initial memory allocation (MB)
-memory = 1280
-
 # Number of VCPUS
 vcpus = 4
 

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-salvator-xs-h3-4x2g.cfg
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-salvator-xs-h3-4x2g.cfg
@@ -15,9 +15,6 @@ device_tree = "/usr/lib/xen/boot/domd.dtb"
 # Kernel command line options
 extra = "video=VGA-1:d video=LVDS-1:d root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0"
 
-# Initial memory allocation (MB)
-memory = 2048
-
 # Number of VCPUS
 vcpus = 4
 

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-salvator-xs-m3-2x4g.cfg
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-salvator-xs-m3-2x4g.cfg
@@ -15,9 +15,6 @@ device_tree = "/usr/lib/xen/boot/domd.dtb"
 # Kernel command line options
 extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0"
 
-# Initial memory allocation (MB)
-memory = 2048
-
 # Number of VCPUS
 vcpus = 4
 

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-salvator-xs-m3n.cfg
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-salvator-xs-m3n.cfg
@@ -15,9 +15,6 @@ device_tree = "/usr/lib/xen/boot/domd.dtb"
 # Kernel command line options
 extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 modprobe.blacklist=sata_rcar"
 
-# Initial memory allocation (MB)
-memory = 1024
-
 # Number of VCPUS
 vcpus = 2
 

--- a/prod-devel-rcar-agl.yaml
+++ b/prod-devel-rcar-agl.yaml
@@ -21,6 +21,7 @@ variables:
   XT_DOMA_SOURCE_GROUP: ""
   XT_MULTIMEDIA_EVA_DIR : ""
   XT_PREBUILT_GSX_DIR: ""
+  XT_MACHINEOVERRIDES_RAM: "mem8gb"
 common_data:
   # Sources used by all yocto-based domains
   sources: &COMMON_SOURCES
@@ -165,6 +166,8 @@ components:
 
         # Do not install kernel image to rootfs to decrease initrd size
         - ["RDEPENDS_${KERNEL_PACKAGE_NAME}-base", ""]
+
+        - [MACHINEOVERRIDES:append, ":%{XT_MACHINEOVERRIDES_RAM}"]
 
       layers:
         - "../meta-virtualization"
@@ -464,6 +467,7 @@ parameters:
           XT_OP_TEE_FLAVOUR: "salvator_m3"
           XT_DOMD_DTB_NAME: "r8a77960-%{MACHINE}-domd.dtb"
           XT_XEN_DTB_NAME: "r8a77960-%{MACHINE}-xen.dtb"
+          XT_MACHINEOVERRIDES_RAM: "mem4gb"
     salvator-xs-m3-2x4g:
       # This is not misprint. This machine has 2x4 memory config
       overrides:
@@ -556,6 +560,7 @@ parameters:
           XT_OP_TEE_FLAVOUR: "salvator_m3"
           XT_DOMD_DTB_NAME: "r8a7796-m3ulcb-domd.dtb"
           XT_XEN_DTB_NAME: "r8a7796-m3ulcb-xen.dtb"
+          XT_MACHINEOVERRIDES_RAM: "mem4gb"
 
   ENABLE_ANDROID:
     desc: "Build Android as a guest VM"
@@ -573,6 +578,10 @@ parameters:
                 - [DISTRO_FEATURES_append, " ivi-shell"]
           dom0:
             builder:
+              conf:
+                # Flag, which allows to override parameters on the Yocto level.
+                # E.g. amount of used RAM for driver domain.
+                - [OVERRIDES:append, ":enable_android"]
               additional_deps:
                 # This is not actually a hard dep. We just want to force Android build
                 - "../%{DOMA_DIR}/out/target/product/xenvm/boot.img"
@@ -781,6 +790,9 @@ parameters:
               conf:
                 # We do not need displbe & sndbe in case of virtio
                 - [DISTRO_FEATURES:remove, " displbe sndbe"]
+                # Flag, which allows to override parameters on the Yocto level.
+                # E.g. amount of used RAM for driver and guest domains.
+                - [OVERRIDES:append, ":enable_virtio"]
           domd:
             builder:
               conf:

--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -26,6 +26,7 @@ variables:
   XT_MULTIMEDIA_EVA_DIR : ""
   XT_PREBUILT_GSX_DIR: ""
   XT_USE_DDK1_11: "0"
+  XT_MACHINEOVERRIDES_RAM: "mem8gb"
 common_data:
   # Sources used by all yocto-based domains
   sources: &COMMON_SOURCES
@@ -186,6 +187,8 @@ components:
         # Build our own Xen version rather than proposed by meta-virtualization
         - [PREFERRED_VERSION_xen, "4.17.0+git%"]
         - [PREFERRED_VERSION_xen-tools, "4.17.0+git%"]
+
+        - [MACHINEOVERRIDES:append, ":%{XT_MACHINEOVERRIDES_RAM}"]
 
       layers:
         - "../meta-virtualization"
@@ -423,6 +426,7 @@ parameters:
           XT_OP_TEE_FLAVOUR: "salvator_m3"
           XT_DOMD_DTB_NAME: "r8a77960-%{MACHINE}-domd.dtb"
           XT_XEN_DTB_NAME: "r8a77960-%{MACHINE}-xen.dtb"
+          XT_MACHINEOVERRIDES_RAM: "mem4gb"
     salvator-xs-m3-2x4g:
       # This is not misprint. This machine has 2x4 memory config
       overrides:
@@ -515,6 +519,7 @@ parameters:
           XT_OP_TEE_FLAVOUR: "salvator_m3"
           XT_DOMD_DTB_NAME: "r8a7796-m3ulcb-domd.dtb"
           XT_XEN_DTB_NAME: "r8a7796-m3ulcb-xen.dtb"
+          XT_MACHINEOVERRIDES_RAM: "mem4gb"
 
   ENABLE_ANDROID:
     desc: "Build Android as a guest VM"
@@ -532,6 +537,10 @@ parameters:
               conf:
                 - [DISTRO_FEATURES:append, " ivi-shell"]
           dom0:
+            conf:
+              # Flag, which allows to override parameters on the Yocto level.
+              # E.g. amount of used RAM for driver domain.
+              - [OVERRIDES:append, ":enable_android"]
             builder:
               additional_deps:
                 # This is not actually a hard dep. We just want to force Android build
@@ -759,6 +768,9 @@ parameters:
               conf:
                 # We do not need displbe & sndbe in case of virtio
                 - [DISTRO_FEATURES:remove, " displbe sndbe"]
+                # Flag, which allows to override parameters on the Yocto level.
+                # E.g. amount of used RAM for driver and guest domains.
+                - [OVERRIDES:append, ":enable_virtio"]
           domd:
             builder:
               conf:


### PR DESCRIPTION
Usually, in cases when Android is used, for 8 Gb RAM boards we assign 2Gb of RAM to DomD and 5Gb of RAM to DomA.

But if on top of that we are using virtio devices, we need to assign 3Gb of RAM to DomD and reduce amount of RAM on DomA to 4Gb. That is caused by a QEMU, which is running in the DomD to provide virtio backends. It requires additional RAM. Without this change QEMU will from time to time crash due to the insufficient amount of memory.

This patch is replacing statically defined RAM parameters in DomD and DomA Xen configuration files, and replaces them with the values, which are conditionally selected by Yocto. That is done using the OVERRIDES and MACHINEOVERRIDES mechanisms. Selected values are then injected into the installed doma.cfg and domd.cfg files.