### PR TITLE
yaml: set PREFERRED_PROVIDER for virtual/libgles3

### DIFF
--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -85,6 +85,7 @@ common_data:
     - [DISTRO_FEATURES:append, " pam"]
     - [PREFERRED_PROVIDER_virtual/libgles1, ""]
     - [PREFERRED_PROVIDER_virtual/libgles2, "gles-user-module"]
+    - [PREFERRED_PROVIDER_virtual/libgles3, "gles-user-module"]
     - [PREFERRED_PROVIDER_virtual/egl, "libegl"]
     - [PREFERRED_PROVIDER_virtual/libgl, ""]
     - [PREFERRED_PROVIDER_virtual/mesa, ""]


### PR DESCRIPTION
There are some packages (like kmscube) which require libgles3. Imagination DDK actually provides support for this standard, but for some reason it was not advertised in recipes provided by Renesas. There is a patch to meta-xt-rcar that sets PROVIDE variable, and there we need to chose correct PREFERRED_PROVIDER in the same way as we did for libgles2.