### PR TITLE
recipes-kernel: finish updating for Renesas BSP v5.9.0

### DIFF
--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-m3ulcb.cfg
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-m3ulcb.cfg
@@ -115,8 +115,6 @@ irqs = [
     42,
 # gpio@e6055800
     43,
-# mfis-as
-    212,
 # interrupt-controller@e61c0000
     32, 33, 34, 35, 193, 50,
 # i2c@e60b0000

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-salvator-x-m3.cfg
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-salvator-x-m3.cfg
@@ -129,8 +129,6 @@ irqs = [
     42,
 # gpio@e6055800
     43,
-# mfis-as
-    212,
 # interrupt-controller@e61c0000
     32, 33, 34, 35, 193, 50,
 # i2c@e6510000

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-salvator-xs-m3-2x4g.cfg
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-salvator-xs-m3-2x4g.cfg
@@ -49,7 +49,6 @@ dt_passthrough_nodes = [
     "/can",
     "/scif",
     "/pcie_bus",
-    "/msiof-ref-clock",
     "/soc",
     "/audio-clkout",
     "/avb-mch@ec5a0100",
@@ -139,8 +138,6 @@ irqs = [
     42,
 # gpio@e6055800
     43,
-# mfis-as
-    212,
 # interrupt-controller@e61c0000
     32, 33, 34, 35, 193, 50,
 # i2c@e6510000
@@ -157,8 +154,6 @@ irqs = [
     216,
 # csi2@feaa0000
     278,
-# rpc0@ee200000
-    70,
 # video@e6ef0000
     220,
 # video@e6ef1000
@@ -343,12 +338,6 @@ iomem = [
     "fea80,10",
 #csi2@feaa0000
     "feaa0,10",
-#rpc0@ee200000
-    "ee200,1",
-#rpc0@ee200000
-    "08000,4000",
-#rpc0@ee200000
-    "ee208,1",
 #video@e6ef0000
     "e6ef0,1",
 #video@e6ef1000

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-salvator-xs-m3n.cfg
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domd/files/domd-salvator-xs-m3n.cfg
@@ -130,8 +130,6 @@ irqs = [
     42,
 # gpio@e6055800
     43,
-# mfis-as
-    212,
 # interrupt-controller@e61c0000
     32, 33, 34, 35, 193, 50,
 # i2c@e60b0000

--- a/meta-xt-prod-devel-rcar-driver-domain/recipes-kernel/linux/files/r8a77951-h3ulcb-xen.dts
+++ b/meta-xt-prod-devel-rcar-driver-domain/recipes-kernel/linux/files/r8a77951-h3ulcb-xen.dts
@@ -316,7 +316,6 @@
 &i2c4			{ xen,passthrough; };
 &i2c_dvfs		{ xen,passthrough; };
 &intc_ex		{ xen,passthrough; };
-&mfis_as		{ xen,passthrough; };
 &sdhi0			{ xen,passthrough; };
 &sdhi2			{ xen,passthrough; };
 &src0			{ xen,passthrough; };

--- a/meta-xt-prod-devel-rcar-driver-domain/recipes-kernel/linux/files/r8a7796-m3ulcb-xen.dts
+++ b/meta-xt-prod-devel-rcar-driver-domain/recipes-kernel/linux/files/r8a7796-m3ulcb-xen.dts
@@ -252,7 +252,6 @@
 &i2c4			{ xen,passthrough; };
 &i2c_dvfs		{ xen,passthrough; };
 &intc_ex		{ xen,passthrough; };
-&mfis_as		{ xen,passthrough; };
 &pmic			{ xen,passthrough; };
 &sdhi0			{ xen,passthrough; };
 &sdhi2			{ xen,passthrough; };

--- a/meta-xt-prod-devel-rcar-driver-domain/recipes-kernel/linux/files/r8a77960-salvator-x-xen.dts
+++ b/meta-xt-prod-devel-rcar-driver-domain/recipes-kernel/linux/files/r8a77960-salvator-x-xen.dts
@@ -276,7 +276,6 @@
 &i2c2			{ xen,passthrough; };
 &i2c4			{ xen,passthrough; };
 &intc_ex		{ xen,passthrough; };
-&mfis_as		{ xen,passthrough; };
 &pciec1			{ xen,passthrough; };
 &pciec0			{ xen,passthrough; };
 &sdhi0			{ xen,passthrough; };

--- a/meta-xt-prod-devel-rcar-driver-domain/recipes-kernel/linux/files/r8a77961-salvator-xs-2x4g-xen.dts
+++ b/meta-xt-prod-devel-rcar-driver-domain/recipes-kernel/linux/files/r8a77961-salvator-xs-2x4g-xen.dts
@@ -210,6 +210,12 @@
 		lossy_shmem {
 			reg = <0 0x47fd7000 0 0x1000>;
 		};
+		imrlx4_imr0 {
+			xen,passthrough;
+		};
+		imrlx4_imr1 {
+			xen,passthrough;
+		};
 	};
 };
 
@@ -336,10 +342,8 @@
 &i2c2			{ xen,passthrough; };
 &i2c4			{ xen,passthrough; };
 &intc_ex		{ xen,passthrough; };
-&mfis_as		{ xen,passthrough; };
 &pciec1			{ xen,passthrough; };
 &pciec0			{ xen,passthrough; };
-&rpc0			{ xen,passthrough; };
 &hscif1			{ xen,passthrough; };
 &sdhi0			{ xen,passthrough; };
 &sdhi2			{ xen,passthrough; };


### PR DESCRIPTION
Commit 30f9eb907d08 ("recipes-kernel: Update Linux for Renesas BSP v5.9.0") updated part of the device trees and recipes, but not all of them, so some of the boards was left in broken state. This commit finishes the work by updating the following boards:

 - r8a77961-salvator-xs-2x4g (aka Salvator-XS M3W)
 - r8a77960-salvator-x-m3 (aka Salvator-X M3N)
 - r8a7796-m3ulcb (aka StarterKit Pro)
 - r8a77951-h3ulcb (aka StarterKit Premiere)


Fixes: 30f9eb907d08 ("recipes-kernel: Update Linux for Renesas BSP v5.9.0")
Reviewed-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com> [for Salvator-XS M3W]