### PR TITLE
Integration of QEMU v7.0.0 + switching to the Xen 4.18

### DIFF
--- a/meta-xt-domd-gen3/recipes-core/images/core-image-weston.bbappend
+++ b/meta-xt-domd-gen3/recipes-core/images/core-image-weston.bbappend
@@ -1,0 +1,3 @@
+IMAGE_INSTALL:append = "\
+    ${@bb.utils.contains('DISTRO_FEATURES', 'enable_virtio', ' virglrenderer libsdl2 qemu-system-aarch64 qemu-keymaps', '', d)} \
+"

--- a/meta-xt-domd-gen3/recipes-graphics/libsdl2/libsdl2_%.bbappend
+++ b/meta-xt-domd-gen3/recipes-graphics/libsdl2/libsdl2_%.bbappend
@@ -1,0 +1,2 @@
+PACKAGECONFIG:append = "${@bb.utils.contains('DISTRO_FEATURES', 'enable_virtio', ' arm-neon', '', d)}"
+PACKAGECONFIG:remove = "${@bb.utils.contains('DISTRO_FEATURES', 'enable_virtio', ' opengl', '', d)}"

--- a/meta-xt-domd-gen3/recipes-qemu/qemu/qemu_%.bbappend
+++ b/meta-xt-domd-gen3/recipes-qemu/qemu/qemu_%.bbappend
@@ -1,0 +1,2 @@
+PACKAGECONFIG:append = "${@bb.utils.contains('DISTRO_FEATURES', 'enable_virtio', ' gtk+', '', d)}"
+PACKAGECONFIG:remove = "${@bb.utils.contains('DISTRO_FEATURES', 'enable_virtio', ' kvm', '', d)}"

--- a/meta-xt-domx-gen3/recipes-extended/xen/xen-source.inc
+++ b/meta-xt-domx-gen3/recipes-extended/xen/xen-source.inc
@@ -1,4 +1,4 @@
 LIC_FILES_CHKSUM = "file://COPYING;md5=d1a1e216f80b6d8da95fec897d0dbec9"
 
-SRC_URI = "git://github.com/xen-troops/xen.git;protocol=https;branch=xen-4.17-xt0.1"
-XEN_REL = "4.17"
+SRC_URI = "git://github.com/xen-troops/xen.git;protocol=https;branch=xen-4.18-xt0.1"
+XEN_REL = "4.18"

--- a/prod-devel-rcar-agl.yaml
+++ b/prod-devel-rcar-agl.yaml
@@ -793,6 +793,13 @@ parameters:
                 # Flag, which allows to override parameters on the Yocto level.
                 # E.g. amount of used RAM for driver and guest domains.
                 - [OVERRIDES:append, ":enable_virtio"]
+                # QEMU configuration
+                - [QEMUVERSION, "7.0%"]
+                # Enable related distro-feautre in order to create conditions in Yocto recipes
+                - [DISTRO_FEATURES:append, " enable_virtio"]
+                - [DISTRO_FEATURES:append, " xen vmsep"]
+              layers:
+                - "../meta-xt-common/meta-xt-qemu"
           domd:
             builder:
               conf:
@@ -800,3 +807,10 @@ parameters:
                 - [DISTRO_FEATURES:remove, " displbe sndbe"]
                 # We do not need ivi-shell in case of virtio
                 - [DISTRO_FEATURES:remove, " ivi-shell"]
+                # Enable xen-virtio distro feature
+                - [DISTRO_FEATURES:append, " enable_virtio"]
+                # QEMU-related configuration
+                - [DISTRO_FEATURES:append, " xen vmsep"]
+                - [QEMUVERSION, "7.0%"]
+              layers:
+                - "../meta-xt-common/meta-xt-qemu"

--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -537,11 +537,11 @@ parameters:
               conf:
                 - [DISTRO_FEATURES:append, " ivi-shell"]
           dom0:
-            conf:
-              # Flag, which allows to override parameters on the Yocto level.
-              # E.g. amount of used RAM for driver domain.
-              - [OVERRIDES:append, ":enable_android"]
             builder:
+              conf:
+                # Flag, which allows to override parameters on the Yocto level.
+                # E.g. amount of used RAM for driver domain.
+                - [OVERRIDES:append, ":enable_android"]
               additional_deps:
                 # This is not actually a hard dep. We just want to force Android build
                 - "../%{DOMA_DIR}/out/target/product/xenvm/boot.img"

--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -185,8 +185,8 @@ components:
         - ["RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base", ""]
 
         # Build our own Xen version rather than proposed by meta-virtualization
-        - [PREFERRED_VERSION_xen, "4.17.0+git%"]
-        - [PREFERRED_VERSION_xen-tools, "4.17.0+git%"]
+        - [PREFERRED_VERSION_xen, "4.18.0+git%"]
+        - [PREFERRED_VERSION_xen-tools, "4.18.0+git%"]
 
         - [MACHINEOVERRIDES:append, ":%{XT_MACHINEOVERRIDES_RAM}"]
 
@@ -243,8 +243,8 @@ components:
         - [XT_MULTIMEDIA_EVA_DIR, "%{XT_MULTIMEDIA_EVA_DIR}"]
 
         # Build our own Xen version rather than proposed by meta-virtualization
-        - [PREFERRED_VERSION_xen, "4.17.0+git%"]
-        - [PREFERRED_VERSION_xen-tools, "4.17.0+git%"]
+        - [PREFERRED_VERSION_xen, "4.18.0+git%"]
+        - [PREFERRED_VERSION_xen-tools, "4.18.0+git%"]
 
       build_target: core-image-weston
       layers:

--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -771,6 +771,13 @@ parameters:
                 # Flag, which allows to override parameters on the Yocto level.
                 # E.g. amount of used RAM for driver and guest domains.
                 - [OVERRIDES:append, ":enable_virtio"]
+                # QEMU configuration
+                - [QEMUVERSION, "7.0%"]
+                # Enable related distro-feautre in order to create conditions in Yocto recipes
+                - [DISTRO_FEATURES:append, " enable_virtio"]
+                - [DISTRO_FEATURES:append, " xen vmsep"]
+              layers:
+                - "../meta-xt-common/meta-xt-qemu"
           domd:
             builder:
               conf:
@@ -778,3 +785,10 @@ parameters:
                 - [DISTRO_FEATURES:remove, " displbe sndbe"]
                 # We do not need ivi-shell in case of virtio
                 - [DISTRO_FEATURES:remove, " ivi-shell"]
+                # Enable xen-virtio distro feature
+                - [DISTRO_FEATURES:append, " enable_virtio"]
+                # QEMU-related configuration
+                - [DISTRO_FEATURES:append, " xen vmsep"]
+                - [QEMUVERSION, "7.0%"]
+              layers:
+                - "../meta-xt-common/meta-xt-qemu"


### PR DESCRIPTION
xen & xen-tools: Switch to Xen 4.18
To use the virtio approach for sharing devices between the driver and the
guest Xen domains we need to switch to the Xen version 4.18. It contains
the required patches for the virtio use cases.

This patch switches to the usage of the xen-troops/xen of branch
xen-4.18-xt0.1, which is Xen of version 4.18 with additional xen-troops
patches on top of it, which were not yet upstreamed.

Signed-off-by: Vladyslav Goncharuk <vladyslav_goncharuk@epam.com>

----

yaml: Fix wrong moulin syntax in build config
For 'yes' literal of the 'ENABLE_ANDROID' parameter, for dom0, there was
a 'conf' section, which was declared outside of the 'builder'. That lead
to doma.cfg with an empty memory parameter, which blocked the start of
the Android OS.

This patch fixes the error in the configuration file.

Signed-off-by: Vladyslav Goncharuk <vladyslav_goncharuk@epam.com>

----

Browse the repository at this point in the history
yaml: Install qemu and friends into DomD
Now with having all required changes integrated into QEMU and
meta-xt-common we can set up an environment for DomD to get a proper
thin Xen-aware qemu-system-aarch64 with required dependencies.

At the same time, this patch adjusts an environment for Dom0 according
to the recent QEMU and meta-xt-common changes.

Signed-off-by: Vladyslav Goncharuk <vladyslav_goncharuk@epam.com>