### PR TITLE
doma & domu: Add installation of the systemd directory

### DIFF
--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domu/domu.bbappend
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domu/domu.bbappend
@@ -43,6 +43,7 @@ do_install:append() {
     # Install domu-set-root script
     install -d ${D}${libdir}/xen/bin
     install -m 0744 ${WORKDIR}/domu-set-root ${D}${libdir}/xen/bin
+    install -d ${D}${sysconfdir}/systemd/system/domu.service.d
 
     if ${@bb.utils.contains('DISTRO_FEATURES', 'sndbe', 'true', 'false', d)}; then
         install -m 0644 ${WORKDIR}/sndbe-backend.conf ${D}${sysconfdir}/systemd/system/domu.service.d


### PR DESCRIPTION
Build fails with the following error:

| install: cannot create regular file
'/home/lorc/work/builtbot-worker/meta-xt-prod-devel-rcar/build/yocto/ build-dom0/tmp/work/aarch64-poky-linux/domu/0.1-r0/image/etc/systemd/ system/domu.service.d': No such file or directory

This patch is intended to add installation of the systemd directory before making an attempt to install files into it.