### PR TITLE
dom-0: xen config 'device_tree' dynamic filling

### DIFF
--- a/meta-xt-prod-devel-rcar-control/recipes-guests/doma/doma.bbappend
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/doma/doma.bbappend
@@ -44,4 +44,8 @@ do_install:append() {
     if ${@bb.utils.contains('DISTRO_FEATURES', 'displbe', 'true', 'false', d)}; then
         install -m 0644 ${WORKDIR}/displbe-backend.conf ${D}${sysconfdir}/systemd/system/doma.service.d
     fi
+
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'enable_virtio', 'false', 'true', d)}; then
+        echo "device_tree = \"/usr/lib/xen/boot/doma.dtb\"" >> ${D}${sysconfdir}/xen/doma.cfg
+    fi
 }

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/doma/files/doma-generic-h3-4x2g.cfg
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/doma/files/doma-generic-h3-4x2g.cfg
@@ -6,8 +6,6 @@ name = "DomA"
 # Kernel image to boot
 kernel = "/usr/lib/xen/boot/u-boot-doma"
 
-device_tree = "/usr/lib/xen/boot/doma.dtb"
-
 dtdev = [
     "/soc/gsx_pv0_domu",
     "/soc/gsx_pv1_domu",

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/doma/files/doma-generic-m3-2x4g.cfg
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/doma/files/doma-generic-m3-2x4g.cfg
@@ -6,8 +6,6 @@ name = "DomA"
 # Kernel image to boot
 kernel = "/usr/lib/xen/boot/u-boot-doma"
 
-device_tree = "/usr/lib/xen/boot/doma.dtb"
-
 dtdev = [
     "/soc/gsx_pv0_domu",
     "/soc/gsx_pv1_domu",

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domu/domu.bbappend
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domu/domu.bbappend
@@ -28,6 +28,10 @@ do_install:append() {
         echo "After=backend-ready@camerabe.service" >> ${D}${systemd_unitdir}/system/domu.service
     fi
 
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'enable_virtio', 'false', 'true', d)}; then
+        echo "device_tree = \"/usr/lib/xen/boot/domu.dtb\"" >> ${CFG_FILE}
+    fi
+
     if ${@bb.utils.contains('DISTRO_FEATURES', 'virtio', 'true', 'false', d)}; then
         sed -i 's/3, xvda1/3, xvda1, virtio/' ${CFG_FILE}
 

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domu/domu.bbappend
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domu/domu.bbappend
@@ -47,13 +47,14 @@ do_install:append() {
     # Install domu-set-root script
     install -d ${D}${libdir}/xen/bin
     install -m 0744 ${WORKDIR}/domu-set-root ${D}${libdir}/xen/bin
-    install -d ${D}${sysconfdir}/systemd/system/domu.service.d
 
     if ${@bb.utils.contains('DISTRO_FEATURES', 'sndbe', 'true', 'false', d)}; then
+        install -d ${D}${sysconfdir}/systemd/system/domu.service.d
         install -m 0644 ${WORKDIR}/sndbe-backend.conf ${D}${sysconfdir}/systemd/system/domu.service.d
     fi
 
     if ${@bb.utils.contains('DISTRO_FEATURES', 'displbe', 'true', 'false', d)}; then
+        install -d ${D}${sysconfdir}/systemd/system/domu.service.d
         install -m 0644 ${WORKDIR}/displbe-backend.conf ${D}${sysconfdir}/systemd/system/domu.service.d
     fi
 

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domu/files/domu-generic-h3-4x2g.cfg
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domu/files/domu-generic-h3-4x2g.cfg
@@ -10,8 +10,6 @@ name = "DomU"
 # Kernel image to boot
 kernel = "/usr/lib/xen/boot/linux-domu"
 
-device_tree = "/usr/lib/xen/boot/domu.dtb"
-
 dtdev = [
     "/soc/gsx_pv0_domu",
     "/soc/gsx_pv1_domu",

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domu/files/domu-generic-m3-2x4g.cfg
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domu/files/domu-generic-m3-2x4g.cfg
@@ -10,8 +10,6 @@ name = "DomU"
 # Kernel image to boot
 kernel = "/usr/lib/xen/boot/linux-domu"
 
-device_tree = "/usr/lib/xen/boot/domu.dtb"
-
 dtdev = [
     "/soc/gsx_pv0_domu",
     "/soc/gsx_pv1_domu",

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domu/files/domu-m3ulcb.cfg
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domu/files/domu-m3ulcb.cfg
@@ -10,8 +10,6 @@ name = "DomU"
 # Kernel image to boot
 kernel = "/usr/lib/xen/boot/linux-domu"
 
-device_tree = "/usr/lib/xen/boot/domu.dtb"
-
 # Kernel command line options
 # In case of using virtio-blk device this should be "root=/dev/vda"
 extra = "root=/dev/xvda1 rw rootwait console=hvc0 cma=128M pvrsrvkm.DriverMode=1"

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domu/files/domu-salvator-x-m3.cfg
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domu/files/domu-salvator-x-m3.cfg
@@ -10,8 +10,6 @@ name = "DomU"
 # Kernel image to boot
 kernel = "/usr/lib/xen/boot/linux-domu"
 
-device_tree = "/usr/lib/xen/boot/domu.dtb"
-
 # Kernel command line options
 # In case of using virtio-blk device this should be "root=/dev/vda"
 extra = "root=/dev/xvda1 rw rootwait console=hvc0 cma=256M pvrsrvkm.DriverMode=1"

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domu/files/domu-salvator-xs-m3n.cfg
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domu/files/domu-salvator-xs-m3n.cfg
@@ -10,8 +10,6 @@ name = "DomU"
 # Kernel image to boot
 kernel = "/usr/lib/xen/boot/linux-domu"
 
-device_tree = "/usr/lib/xen/boot/domu.dtb"
-
 # Kernel command line options
 # In case of using virtio-blk device this should be "root=/dev/vda"
 extra = "root=/dev/xvda1 rw rootwait console=hvc0 cma=128M pvrsrvkm.DriverMode=1"


### PR DESCRIPTION
Implement dynamic filling 'device_tree' parameter in xen configuration files for dom-u and dom-a depending on build configuration.