### PR TITLE
yaml: wrap domain-specific variables under switches

### DIFF
--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -11,7 +11,7 @@ variables:
   DOMZ_DIR: "zephyr"
   XT_DOMD_DTB_NAME: "%{SOC_FAMILY}-%{MACHINE}-domd.dtb"
   XT_DOMU_DTB_NAME: "salvator-generic-domu.dtb"
-  XT_DOMA_DTB_NAME: "salvator-generic-doma.dtb"
+  XT_DOMA_DTB_NAME: ""
   XT_XEN_DTB_NAME: "%{SOC_FAMILY}-%{MACHINE}-xen.dtb"
   XT_PVR_NUM_OSID: "2"
   XT_OP_TEE_FLAVOUR: "generic_dt"
@@ -162,12 +162,7 @@ components:
         - *COMMON_CONF
         - [MACHINE, "generic-armv8-xt"]
         - [XT_DOMD_CONFIG_NAME, "%{XT_DOMD_CONFIG_NAME}"]
-        - [XT_DOMU_CONFIG_NAME, "%{XT_DOMU_CONFIG_NAME}"]
-        - [XT_DOMA_CONFIG_NAME, "%{XT_DOMA_CONFIG_NAME}"]
-        - [XT_DOMZ_CONFIG_NAME, "%{XT_DOMZ_CONFIG_NAME}"]
         - [XT_DOMD_DTB_NAME, "%{XT_DOMD_DTB_NAME}"]
-        - [XT_DOMU_DTB_NAME, "%{XT_DOMU_DTB_NAME}"]
-        - [XT_DOMA_DTB_NAME, "%{XT_DOMA_DTB_NAME}"]
         - [XT_DOM_NAME, "dom0"]
         - [XT_GUEST_INSTALL, "%{XT_GENERIC_DOMU_TAG} %{XT_DOMA_TAG} %{XT_DOMZ_TAG} domd"]
 
@@ -508,6 +503,7 @@ parameters:
         variables:
           XT_DOMA_TAG: "doma"
           XT_USE_DDK1_11: "1"
+          XT_DOMA_DTB_NAME: "salvator-generic-doma.dtb"
         components:
           # Build and install ivi-shell in case of Android builds
           domd:
@@ -517,6 +513,8 @@ parameters:
           dom0:
             builder:
               conf:
+                - [XT_DOMA_DTB_NAME, "%{XT_DOMA_DTB_NAME}"]
+                - [XT_DOMA_CONFIG_NAME, "%{XT_DOMA_CONFIG_NAME}"]
                 # Flag, which allows to override parameters on the Yocto level.
                 # E.g. amount of used RAM for driver domain.
                 - [OVERRIDES:append, ":enable_android"]
@@ -597,6 +595,9 @@ parameters:
         components:
           dom0:
             builder:
+              conf:
+                - [XT_DOMU_DTB_NAME, "%{XT_DOMU_DTB_NAME}"]
+                - [XT_DOMU_CONFIG_NAME, "%{XT_DOMU_CONFIG_NAME}"]
               additional_deps:
                 - "%{DOMU_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/Image"
               external_src:
@@ -620,6 +621,8 @@ parameters:
         components:
           dom0:
             builder:
+              conf:
+                - [XT_DOMZ_CONFIG_NAME, "%{XT_DOMZ_CONFIG_NAME}"]
               additional_deps:
                 # paths relative to dom0 build-dir
                 - "../%{DOMZ_DIR}/zephyr/build/zephyr/zephyr.bin"


### PR DESCRIPTION
Some domain-specific things, like .dtb and .cfg are always used without any regard to the presence of corresponding domains. This commit wraps all domain-specific stuff under corresponding switches.