### PR TITLE
virtio: Do not run GSX driver in Host mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,10 @@ with proprietary sources. But you may use prebuilt graphics binaries.
 Please see instruction below.
 
 1. You need to have prebuilt graphic binaries. Pay attention that you
-can't use prebuilt binaries from Renesas because those packages
-do not support virtualization.
+can't use prebuilt binaries from Renesas for the non-virtio build because
+those packages do not support virtualization. For the virtio build,
+on the contrary, prebuilt binaries from Renesas must be used because of
+GPU passthrough (native mode) instead of GPU sharing is in use there.
 2. Put these binaries into `<directory_with_yaml>/../prebuilt_gsx/`.
 By default prebuilt binaries are expected to be in the dedicated folder
 on the same level as your folder with yaml. But this can be changed in

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domd/domd.bbappend
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domd/domd.bbappend
@@ -32,5 +32,6 @@ do_install:append() {
     if ${@bb.utils.contains('DISTRO_FEATURES', 'enable_virtio', 'true', 'false', d)}; then
         echo "" >> ${CFG_FILE}
         echo "driver_domain = 1" >> ${CFG_FILE}
+        sed -i "s/pvrsrvkm.DriverMode=0/pvrsrvkm.DriverMode=0x7fffffff/g" ${CFG_FILE}
     fi
 }


### PR DESCRIPTION
When the prebuilt graphics package is chosen, the GPU passthrough (native mode) is used. So we don't need to force virt (host) mode in Linux driver.