### PR TITLE
yaml: unite options related to prebuilt GFX (GSX) DDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,7 @@ usage: moulin prod-devel-rcar.yaml
        [--MACHINE {salvator-x-m3,salvator-xs-m3-2x4g,salvator-xs-h3-4x2g,salvator-x-h3-4x2g,h3ulcb-4x2g,h3ulcb-4x2g-kf,h3ulcb-4x2g-ab,m3ulcb}]
        [--ENABLE_ANDROID {no,yes}] [--ENABLE_DOMU {no,yes}]
        [--ENABLE_ZEPHYR {no,yes}] [--ENABLE_MM {no,yes}]
-       [--ENABLE_AOS_VIS {no,yes}] [--PREBUILT_DDK {no,yes}]
-       [--ANDROID_PREBUILT_DDK {no,yes}]
+       [--ENABLE_AOS_VIS {no,yes}] [--GRAPHICS {binaries,sources}]
 
 Config file description: Xen-Troops development setup for Renesas RCAR Gen3
 hardware
@@ -110,10 +109,8 @@ optional arguments:
   --ENABLE_MM {no,yes}  Enable Multimedia support
   --ENABLE_AOS_VIS {no,yes}
                         Enable AOS VIS service
-  --PREBUILT_DDK {no,yes}
-                        Use pre-built GPU drivers
-  --ANDROID_PREBUILT_DDK {no,yes}
-                        Use pre-built GPU drivers for Android
+  --GRAPHICS {binaries,sources}]
+                        Select how to use the GFX (3D hardware accelerator)
 ```
 
 To build for Salvator XS M3 8GB with DomU (generic yocto-based virtual
@@ -174,7 +171,7 @@ prebuilt_gsx/
   <... other build related files and directories ...>
 ```
 
-3. Use `--PREBUILT_DDK yes` command line option for moulin.
+3. Use `--GRAPHICS binaries` command line option for moulin.
 
 Run build as usual with `ninja`.
 
@@ -184,7 +181,7 @@ Prior to running moulin, you need to place android graphics prebuilts
 archive `rcar-prebuilts-graphics-xt-doma.tar.gz` in the same directory
 as yaml file.
 
-Use `--ANDROID_PREBUILT_DDK yes` commad line option for moulin.
+Use `--GRAPHICS binaries` command line option for moulin.
 
 ## Creating SD card image
 

--- a/prod-devel-rcar-agl.yaml
+++ b/prod-devel-rcar-agl.yaml
@@ -707,47 +707,27 @@ parameters:
             builder:
               env:
                 - "XT_USE_VIS_SERVER=true"
-  PREBUILT_DDK:
-    desc: "Use pre-built GPU drivers"
-    "no":
-      default: true
-      overrides:
-        components:
-          domd:
-            *DDK_SOURCE_OVERRIDES
-          domu:
-            *DDK_SOURCE_OVERRIDES
-    "yes":
-      # Folder with prebuilt graphics package, i.e. file ${SOC_NAME}_linux_gsx_binaries_gles.tar.gz
-      # is provided as XT_PREBUILT_GSX_DIR variable to components
+  GRAPHICS:
+    desc: "Select how to use the GFX (3D hardware accelerator)"
+    "binaries":
       overrides:
         variables:
+          # for the linux
+          # Directory containing ${SOC_NAME}_linux_gsx_binaries_gles.tar.gz
           XT_PREBUILT_GSX_DIR: "${TOPDIR}/../../../prebuilt_gsx"
-        components:
-          domd:
-            builder:
-              conf:
-                - [XT_PREBUILT_GSX_DIR, "%{XT_PREBUILT_GSX_DIR}"]
-          domu:
-            builder:
-              conf:
-                - [XT_PREBUILT_GSX_DIR, "%{XT_PREBUILT_GSX_DIR}"]
-  ANDROID_PREBUILT_DDK:
-    desc: "Use pre-built GPU drivers for Android"
-    "no":
-      default: true
-      overrides:
-        variables:
-          XT_DOMA_DDK_KM_PREBUILT_MODULE: "../%{ANDROID_KERNEL_DIR}/out/android12-5.4/staging/vendor/lib/modules/pvrsrvkm.ko"
-          XT_DOMA_KERNEL_EXTRA_MODULES: "imagination"
-          XT_DOMA_SOURCE_GROUP: "all"
-    "yes":
-      overrides:
-        variables:
+          # for the android
           XT_DOMA_DDK_KM_PREBUILT_MODULE: "eva/pvr-km/pvrsrvkm.ko"
           XT_DOMA_KERNEL_EXTRA_MODULES: ""
           XT_DOMA_SOURCE_GROUP: "default"
         components:
+          domd:
+            builder:
+              conf:
+                - [XT_PREBUILT_GSX_DIR, "%{XT_PREBUILT_GSX_DIR}"]
+          domu:
+            builder:
+              conf:
+                - [XT_PREBUILT_GSX_DIR, "%{XT_PREBUILT_GSX_DIR}"]
           doma:
             sources:
               - type: unpack
@@ -757,3 +737,18 @@ parameters:
             builder:
               env:
                 - "DDK_UM_PREBUILDS=eva/pvr-um"
+
+    "sources":
+      default: true
+      overrides:
+        # for the linux
+        components:
+          domd:
+            *DDK_SOURCE_OVERRIDES
+          domu:
+            *DDK_SOURCE_OVERRIDES
+        # for the android
+        variables:
+          XT_DOMA_DDK_KM_PREBUILT_MODULE: "../%{ANDROID_KERNEL_DIR}/out/android12-5.4/staging/vendor/lib/modules/pvrsrvkm.ko"
+          XT_DOMA_KERNEL_EXTRA_MODULES: "imagination"
+          XT_DOMA_SOURCE_GROUP: "all"

--- a/prod-devel-rcar-virtio.yaml
+++ b/prod-devel-rcar-virtio.yaml
@@ -729,11 +729,24 @@ parameters:
               env:
                 - "XT_USE_VIS_SERVER=true"
 
-  PREBUILT_DDK:
-    desc: "Use pre-built GPU drivers"
-    "no":
+  GRAPHICS:
+    desc: "Select how to use the GFX (3D hardware accelerator)"
+    "binaries":
+      overrides:
+        variables:
+          # for the linux
+          # Directory containing ${SOC_NAME}_linux_gsx_binaries_gles.tar.gz
+          XT_PREBUILT_GSX_DIR: "${TOPDIR}/../../../prebuilt_gsx"
+        components:
+          domd:
+            builder:
+              conf:
+                - [XT_PREBUILT_GSX_DIR, "%{XT_PREBUILT_GSX_DIR}"]
+
+    "sources":
       default: true
       overrides:
+        # for the linux
         components:
           domd:
             sources:
@@ -742,19 +755,7 @@ parameters:
               conf:
                 # gles-um-compile.bb still requires python2
                 - [I_SWEAR_TO_MIGRATE_TO_PYTHON3, "yes"]
-
               layers:
                 - "../meta-python2"
                 - "../meta-clang"
                 - "../meta-xt-rcar/meta-xt-rcar-proprietary"
-    "yes":
-      # Folder with prebuilt graphics package, i.e. file ${SOC_NAME}_linux_gsx_binaries_gles.tar.gz
-      # is provided as XT_PREBUILT_GSX_DIR variable to components
-      overrides:
-        variables:
-          XT_PREBUILT_GSX_DIR: "${TOPDIR}/../../../prebuilt_gsx"
-        components:
-          domd:
-            builder:
-              conf:
-                - [XT_PREBUILT_GSX_DIR, "%{XT_PREBUILT_GSX_DIR}"]

--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -698,47 +698,27 @@ parameters:
             builder:
               env:
                 - "XT_USE_VIS_SERVER=true"
-  PREBUILT_DDK:
-    desc: "Use pre-built GPU drivers"
-    "no":
-      default: true
-      overrides:
-        components:
-          domd:
-            *DDK_SOURCE_OVERRIDES
-          domu:
-            *DDK_SOURCE_OVERRIDES
-    "yes":
-      # Folder with prebuilt graphics package, i.e. file ${SOC_NAME}_linux_gsx_binaries_gles.tar.gz
-      # is provided as XT_PREBUILT_GSX_DIR variable to components
+  GRAPHICS:
+    desc: "Select how to use the GFX (3D hardware accelerator)"
+    "binaries":
       overrides:
         variables:
+          # for the linux
+          # Directory containing ${SOC_NAME}_linux_gsx_binaries_gles.tar.gz
           XT_PREBUILT_GSX_DIR: "${TOPDIR}/../../../prebuilt_gsx"
-        components:
-          domd:
-            builder:
-              conf:
-                - [XT_PREBUILT_GSX_DIR, "%{XT_PREBUILT_GSX_DIR}"]
-          domu:
-            builder:
-              conf:
-                - [XT_PREBUILT_GSX_DIR, "%{XT_PREBUILT_GSX_DIR}"]
-  ANDROID_PREBUILT_DDK:
-    desc: "Use pre-built GPU drivers for Android"
-    "no":
-      default: true
-      overrides:
-        variables:
-          XT_DOMA_DDK_KM_PREBUILT_MODULE: "../%{ANDROID_KERNEL_DIR}/out/android12-5.4/staging/vendor/lib/modules/pvrsrvkm.ko"
-          XT_DOMA_KERNEL_EXTRA_MODULES: "imagination"
-          XT_DOMA_SOURCE_GROUP: "all"
-    "yes":
-      overrides:
-        variables:
+          # for the android
           XT_DOMA_DDK_KM_PREBUILT_MODULE: "eva/pvr-km/pvrsrvkm.ko"
           XT_DOMA_KERNEL_EXTRA_MODULES: ""
           XT_DOMA_SOURCE_GROUP: "default"
         components:
+          domd:
+            builder:
+              conf:
+                - [XT_PREBUILT_GSX_DIR, "%{XT_PREBUILT_GSX_DIR}"]
+          domu:
+            builder:
+              conf:
+                - [XT_PREBUILT_GSX_DIR, "%{XT_PREBUILT_GSX_DIR}"]
           doma:
             sources:
               - type: unpack
@@ -748,3 +728,18 @@ parameters:
             builder:
               env:
                 - "DDK_UM_PREBUILDS=eva/pvr-um"
+
+    "sources":
+      default: true
+      overrides:
+        # for the linux
+        components:
+          domd:
+            *DDK_SOURCE_OVERRIDES
+          domu:
+            *DDK_SOURCE_OVERRIDES
+        # for the android
+        variables:
+          XT_DOMA_DDK_KM_PREBUILT_MODULE: "../%{ANDROID_KERNEL_DIR}/out/android12-5.4/staging/vendor/lib/modules/pvrsrvkm.ko"
+          XT_DOMA_KERNEL_EXTRA_MODULES: "imagination"
+          XT_DOMA_SOURCE_GROUP: "all"


### PR DESCRIPTION
This commit replaces two options PREBUILT_DDK and ANDROID_PREBUILT_DDK with the single option GRAPHICS.

Possible options are 'binaries' and 'sources' that replace 'yes/no' for the previously used options PREBUILT_*.

Also, README.txt is updated accordingly, with two minor fixes not related to subject (missprint and new line at the end of the file).