### PR TITLE
Rework some IMAGE_INSTALL

### DIFF
--- a/meta-xt-domd-gen3/recipes-core/images/core-image-weston.bbappend
+++ b/meta-xt-domd-gen3/recipes-core/images/core-image-weston.bbappend
@@ -1,4 +1,5 @@
 IMAGE_INSTALL:append = "\
-    ${@bb.utils.contains('DISTRO_FEATURES', 'enable_virtio', ' virglrenderer libsdl2 qemu-system-aarch64 qemu-keymaps', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'enable_virtio wayland', ' virglrenderer libsdl2', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'enable_virtio', ' qemu-system-aarch64 qemu-keymaps', '', d)} \
     iperf3 \
 "

--- a/meta-xt-domd-gen3/recipes-qemu/qemu/qemu_%.bbappend
+++ b/meta-xt-domd-gen3/recipes-qemu/qemu/qemu_%.bbappend
@@ -1,2 +1,3 @@
-PACKAGECONFIG:append = "${@bb.utils.contains('DISTRO_FEATURES', 'enable_virtio', ' gtk+ vhost', '', d)}"
+PACKAGECONFIG:append = "${@bb.utils.contains('DISTRO_FEATURES', 'enable_virtio', ' vhost', '', d)}"
+PACKAGECONFIG:append = "${@bb.utils.contains('DISTRO_FEATURES', 'enable_virtio wayland', ' gtk+', '', d)}"
 PACKAGECONFIG:remove = "${@bb.utils.contains('DISTRO_FEATURES', 'enable_virtio', ' kvm', '', d)}"

--- a/meta-xt-domd-gen3/recipes-tools/images/core-image-weston.bbappend
+++ b/meta-xt-domd-gen3/recipes-tools/images/core-image-weston.bbappend
@@ -1,3 +1,8 @@
 IMAGE_INSTALL:append = " \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'gsx', 'kmscube', '', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'gsx', 'glmark2', '', d)} \
     lisot \
+    expect \
+    ltrace \
+    evtest \
 "

--- a/meta-xt-domu-gen3/recipes-tools/images/core-image-weston.bbappend
+++ b/meta-xt-domu-gen3/recipes-tools/images/core-image-weston.bbappend
@@ -1,6 +1,6 @@
 IMAGE_INSTALL:append = " \
     pciutils \
-    kmscube \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'gsx', 'kmscube', '', d)} \
     iperf3 \
     lisot \
 "

--- a/meta-xt-domu-gen3/recipes-tools/images/core-image-weston.bbappend
+++ b/meta-xt-domu-gen3/recipes-tools/images/core-image-weston.bbappend
@@ -1,6 +1,10 @@
 IMAGE_INSTALL:append = " \
     pciutils \
     ${@bb.utils.contains('MACHINE_FEATURES', 'gsx', 'kmscube', '', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'gsx', 'glmark2', '', d)} \
     iperf3 \
     lisot \
+    expect \
+    ltrace \
+    evtest \
 "

--- a/prod-devel-rcar-virtio.yaml
+++ b/prod-devel-rcar-virtio.yaml
@@ -93,9 +93,6 @@ common_data:
     # HACK: force ipk instead of rpm b/c it makes troubles to PVR UM build otherwise
     - [PACKAGE_CLASSES, "package_ipk"]
 
-    # Additional testing and debug tools
-    - [IMAGE_INSTALL:append, " expect ltrace evtest"]
-
   gfx_conf: &GFX_CONF
     # Configure number of supported GPU virtual guests
     - [XT_PVR_NUM_OSID, "%{XT_PVR_NUM_OSID}"]
@@ -123,9 +120,6 @@ common_data:
     - [BBMASK:append, " ${@bb.utils.contains('XT_USE_DDK1_11', '1', '', 'meta-xt-rcar-fixups/recipes-kernel/kernel-module-gles/kernel-module-gles.bbappend', d)}"]
     - [BBMASK:append, " ${@bb.utils.contains('XT_USE_DDK1_11', '1', '', 'meta-xt-rcar-fixups/recipes-graphics/gles-module/gles-user-module.bbappend', d)}"]
     - [BBMASK:append, " ${@bb.utils.contains('XT_USE_DDK1_11', '1', '', 'meta-xt-rcar-fixups/recipes-graphics/packagegroups/packagegroup-graphic-renesas.bbappend', d)}"]
-
-    # Install some apps to test GPU/Display
-    - [IMAGE_INSTALL:append, " glmark2 kmscube"]
 
   gfx_sources: &GFX_SOURCES
     - type: git

--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -95,9 +95,6 @@ common_data:
     # HACK: force ipk instead of rpm b/c it makes troubles to PVR UM build otherwise
     - [PACKAGE_CLASSES, "package_ipk"]
 
-    # Additional testing and debug tools
-    - [IMAGE_INSTALL:append, " expect ltrace evtest"]
-
   gfx_conf: &GFX_CONF
     # Configure number of supported GPU virtual guests
     - [XT_PVR_NUM_OSID, "%{XT_PVR_NUM_OSID}"]
@@ -125,9 +122,6 @@ common_data:
     - [BBMASK:append, " ${@bb.utils.contains('XT_USE_DDK1_11', '1', '', 'meta-xt-rcar-fixups/recipes-kernel/kernel-module-gles/kernel-module-gles.bbappend', d)}"]
     - [BBMASK:append, " ${@bb.utils.contains('XT_USE_DDK1_11', '1', '', 'meta-xt-rcar-fixups/recipes-graphics/gles-module/gles-user-module.bbappend', d)}"]
     - [BBMASK:append, " ${@bb.utils.contains('XT_USE_DDK1_11', '1', '', 'meta-xt-rcar-fixups/recipes-graphics/packagegroups/packagegroup-graphic-renesas.bbappend', d)}"]
-
-    # Install some apps to test GPU/Display
-    - [IMAGE_INSTALL:append, " glmark2 kmscube"]
 
   gfx_sources: &GFX_SOURCES
     - type: git


### PR DESCRIPTION
- domu: install kmscube only when 3D GSX is used
- domd: domu: move utilities to the tools-related recipes
- virtio: wrap some wayland-related packages