### PR TITLE
domd: domu: add support for core-image-minimal

### DIFF
--- a/meta-xt-domd-gen3/recipes-core/images/common_install.inc
+++ b/meta-xt-domd-gen3/recipes-core/images/common_install.inc
@@ -1,0 +1,4 @@
+IMAGE_INSTALL:append = "\
+    ${@bb.utils.contains('DISTRO_FEATURES', 'enable_virtio', ' qemu-system-aarch64 qemu-keymaps', '', d)} \
+    iperf3 \
+"

--- a/meta-xt-domd-gen3/recipes-core/images/core-image-minimal.bbappend
+++ b/meta-xt-domd-gen3/recipes-core/images/core-image-minimal.bbappend
@@ -1,0 +1,1 @@
+require common_install.inc

--- a/meta-xt-domd-gen3/recipes-core/images/core-image-weston.bbappend
+++ b/meta-xt-domd-gen3/recipes-core/images/core-image-weston.bbappend
@@ -1,5 +1,5 @@
+require common_install.inc
+
 IMAGE_INSTALL:append = "\
     ${@bb.utils.contains('DISTRO_FEATURES', 'enable_virtio wayland', ' virglrenderer libsdl2', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'enable_virtio', ' qemu-system-aarch64 qemu-keymaps', '', d)} \
-    iperf3 \
 "

--- a/meta-xt-domd-gen3/recipes-tools/images/common_install.inc
+++ b/meta-xt-domd-gen3/recipes-tools/images/common_install.inc
@@ -1,0 +1,6 @@
+IMAGE_INSTALL:append = " \
+    lisot \
+    expect \
+    ltrace \
+    evtest \
+"

--- a/meta-xt-domd-gen3/recipes-tools/images/core-image-minimal.bbappend
+++ b/meta-xt-domd-gen3/recipes-tools/images/core-image-minimal.bbappend
@@ -1,0 +1,1 @@
+require common_install.inc

--- a/meta-xt-domd-gen3/recipes-tools/images/core-image-weston.bbappend
+++ b/meta-xt-domd-gen3/recipes-tools/images/core-image-weston.bbappend
@@ -1,8 +1,6 @@
+require common_install.inc
+
 IMAGE_INSTALL:append = " \
     ${@bb.utils.contains('MACHINE_FEATURES', 'gsx', 'kmscube', '', d)} \
     ${@bb.utils.contains('MACHINE_FEATURES', 'gsx', 'glmark2', '', d)} \
-    lisot \
-    expect \
-    ltrace \
-    evtest \
 "

--- a/meta-xt-domu-gen3/recipes-tools/images/common_install.inc
+++ b/meta-xt-domu-gen3/recipes-tools/images/common_install.inc
@@ -1,0 +1,8 @@
+IMAGE_INSTALL:append = " \
+    pciutils \
+    iperf3 \
+    lisot \
+    expect \
+    ltrace \
+    evtest \
+"

--- a/meta-xt-domu-gen3/recipes-tools/images/core-image-minimal.bbappend
+++ b/meta-xt-domu-gen3/recipes-tools/images/core-image-minimal.bbappend
@@ -1,0 +1,1 @@
+require common_install.inc

--- a/meta-xt-domu-gen3/recipes-tools/images/core-image-weston.bbappend
+++ b/meta-xt-domu-gen3/recipes-tools/images/core-image-weston.bbappend
@@ -1,10 +1,6 @@
+require common_install.inc
+
 IMAGE_INSTALL:append = " \
-    pciutils \
     ${@bb.utils.contains('MACHINE_FEATURES', 'gsx', 'kmscube', '', d)} \
     ${@bb.utils.contains('MACHINE_FEATURES', 'gsx', 'glmark2', '', d)} \
-    iperf3 \
-    lisot \
-    expect \
-    ltrace \
-    evtest \
 "

--- a/meta-xt-prod-devel-rcar-driver-domain/recipes-graphics/images/common_install.inc
+++ b/meta-xt-prod-devel-rcar-driver-domain/recipes-graphics/images/common_install.inc
@@ -1,0 +1,4 @@
+IMAGE_INSTALL:append = " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'vis', 'aos-vis', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'sndbe', 'sndbe', '', d)} \
+"

--- a/meta-xt-prod-devel-rcar-driver-domain/recipes-graphics/images/core-image-minimal.bbappend
+++ b/meta-xt-prod-devel-rcar-driver-domain/recipes-graphics/images/core-image-minimal.bbappend
@@ -1,0 +1,1 @@
+require common_install.inc

--- a/meta-xt-prod-devel-rcar-driver-domain/recipes-graphics/images/core-image-weston.bbappend
+++ b/meta-xt-prod-devel-rcar-driver-domain/recipes-graphics/images/core-image-weston.bbappend
@@ -1,7 +1,7 @@
+require common_install.inc
+
 IMAGE_INSTALL:append = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'pvcamera', 'camerabe', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'vis', 'aos-vis', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'sndbe', 'sndbe', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'displbe', 'displbe', '', d)} \
 "
 


### PR DESCRIPTION
This commit adds possibility to build our components inside core-image-minimal.
Parts that are common for core-image-minimal and core-image-weston are moved into the common_install.inc file.