### PR TITLE
yaml: use variable to specify `build_target`

### DIFF
--- a/prod-devel-rcar-agl.yaml
+++ b/prod-devel-rcar-agl.yaml
@@ -11,6 +11,8 @@ variables:
   DOMU_MACHINE: "%{MACHINE}"
   ANDROID_KERNEL_DIR: "android_kernel"
   DOMA_DIR: "android"
+  BUILD_TARGET_DOMD: "agl-demo-platform"
+  BUILD_TARGET_DOMU: "core-image-weston"
   XT_DOMD_DTB_NAME: "%{SOC_FAMILY}-%{DOMD_MACHINE}-domd.dtb"
   XT_DOMU_DTB_NAME: "salvator-generic-domu.dtb"
   XT_DOMA_DTB_NAME: ""
@@ -316,7 +318,7 @@ components:
         # meta-agl/meta-pipewire/conf/include/agl-pipewire.inc
         - [DISTRO_FEATURES:append, " pipewire"]
         - [PREFERRED_RPROVIDER_virtual/wireplumber-config, "wireplumber-config-agl"]
-      build_target: agl-demo-platform
+      build_target: "%{BUILD_TARGET_DOMD}"
       layers:
         - "../meta-renesas/meta-rcar-gen3"
         - "../meta-virtualization"
@@ -347,7 +349,7 @@ components:
         - "tmp/deploy/images/%{DOMD_MACHINE}/xen-%{DOMD_MACHINE}.uImage"
         - "tmp/deploy/images/%{DOMD_MACHINE}/xenpolicy-%{DOMD_MACHINE}"
         - "tmp/deploy/images/%{DOMD_MACHINE}/%{XT_XEN_DTB_NAME}"
-        - "tmp/deploy/images/%{DOMD_MACHINE}/agl-demo-platform-%{DOMD_MACHINE}.ext4"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/%{BUILD_TARGET_DOMD}-%{DOMD_MACHINE}.ext4"
 
   domu:
     build-dir: "%{YOCTOS_WORK_DIR}"
@@ -376,10 +378,10 @@ components:
         - "../meta-xt-common/meta-xt-domu"
         - "../meta-xt-rcar/meta-xt-rcar-fixups"
         - "../meta-xt-rcar/meta-xt-rcar-domu"
-      build_target: core-image-weston
+      build_target: "%{BUILD_TARGET_DOMU}"
       target_images:
         - "tmp/deploy/images/%{DOMU_MACHINE}/Image"
-        - "tmp/deploy/images/%{DOMU_MACHINE}/core-image-weston-%{DOMU_MACHINE}.ext4"
+        - "tmp/deploy/images/%{DOMU_MACHINE}/%{BUILD_TARGET_DOMU}-%{DOMU_MACHINE}.ext4"
 
   doma_kernel:
     build-dir: "%{ANDROID_KERNEL_DIR}"
@@ -446,7 +448,7 @@ images:
       domd_rootfs:
         gpt_type: B921B045-1DF0-41C3-AF44-4C6F280D3FAE # Linux aarch64 root
         type: raw_image
-        image_path: "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{DOMD_MACHINE}/agl-demo-platform-%{DOMD_MACHINE}.ext4"
+        image_path: "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{DOMD_MACHINE}/%{BUILD_TARGET_DOMD}-%{DOMD_MACHINE}.ext4"
 
 parameters:
   # Machines
@@ -638,7 +640,7 @@ parameters:
               domu-rootfs:
                 type: raw_image
                 gpt_type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4 # Linux filesystem data
-                image_path: "%{YOCTOS_WORK_DIR}/%{DOMU_BUILD_DIR}/tmp/deploy/images/%{DOMU_MACHINE}/core-image-weston-%{DOMU_MACHINE}.ext4"
+                image_path: "%{YOCTOS_WORK_DIR}/%{DOMU_BUILD_DIR}/tmp/deploy/images/%{DOMU_MACHINE}/%{BUILD_TARGET_DOMU}-%{DOMU_MACHINE}.ext4"
 
   ENABLE_MM:
     desc: "Enable Multimedia support"

--- a/prod-devel-rcar-virtio.yaml
+++ b/prod-devel-rcar-virtio.yaml
@@ -12,6 +12,8 @@ variables:
   ANDROID_KERNEL_DIR: "android_kernel"
   DOMA_DIR: "android"
   DOMZ_DIR: "zephyr"
+  BUILD_TARGET_DOMD: "core-image-weston"
+  BUILD_TARGET_DOMU: "core-image-weston"
   XT_DOMD_DTB_NAME: "%{SOC_FAMILY}-%{DOMD_MACHINE}-domd.dtb"
   XT_DOMA_DTB_NAME: ""
   XT_XEN_DTB_NAME: "%{SOC_FAMILY}-%{DOMD_MACHINE}-xen.dtb"
@@ -251,7 +253,7 @@ components:
         - [DISTRO_FEATURES:append, " xen vmsep"]
         - [QEMUVERSION, "7.0%"]
 
-      build_target: core-image-weston
+      build_target: "%{BUILD_TARGET_DOMD}"
       layers:
         - "../meta-renesas/meta-rcar-gen3"
         - "../meta-virtualization"
@@ -278,7 +280,7 @@ components:
         - "tmp/deploy/images/%{DOMD_MACHINE}/xen-%{DOMD_MACHINE}.uImage"
         - "tmp/deploy/images/%{DOMD_MACHINE}/xenpolicy-%{DOMD_MACHINE}"
         - "tmp/deploy/images/%{DOMD_MACHINE}/%{XT_XEN_DTB_NAME}"
-        - "tmp/deploy/images/%{DOMD_MACHINE}/core-image-weston-%{DOMD_MACHINE}.ext4"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/%{BUILD_TARGET_DOMD}-%{DOMD_MACHINE}.ext4"
 
   domu:
     build-dir: "%{YOCTOS_WORK_DIR}"
@@ -309,10 +311,10 @@ components:
         - "../meta-xt-common/meta-xt-domu-virtio"
         - "../meta-xt-prod-devel-rcar/meta-xt-domx-gen3"
         - "../meta-xt-prod-devel-rcar/meta-xt-domu-gen3"
-      build_target: core-image-weston
+      build_target: "%{BUILD_TARGET_DOMU}"
       target_images:
         - "tmp/deploy/images/%{DOMU_MACHINE}/Image"
-        - "tmp/deploy/images/%{DOMU_MACHINE}/core-image-weston-%{DOMU_MACHINE}.ext4"
+        - "tmp/deploy/images/%{DOMU_MACHINE}/%{BUILD_TARGET_DOMU}-%{DOMU_MACHINE}.ext4"
 
   doma_kernel:
     build-dir: "%{ANDROID_KERNEL_DIR}"
@@ -416,7 +418,7 @@ images:
       domd_rootfs:
         gpt_type: B921B045-1DF0-41C3-AF44-4C6F280D3FAE # Linux aarch64 root
         type: raw_image
-        image_path: "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{DOMD_MACHINE}/core-image-weston-%{DOMD_MACHINE}.ext4"
+        image_path: "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{DOMD_MACHINE}/%{BUILD_TARGET_DOMD}-%{DOMD_MACHINE}.ext4"
 
 parameters:
   # Machines
@@ -633,7 +635,7 @@ parameters:
               domu-rootfs:
                 type: raw_image
                 gpt_type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4 # Linux filesystem data
-                image_path: "%{YOCTOS_WORK_DIR}/%{DOMU_BUILD_DIR}/tmp/deploy/images/%{DOMU_MACHINE}/core-image-weston-%{DOMU_MACHINE}.ext4"
+                image_path: "%{YOCTOS_WORK_DIR}/%{DOMU_BUILD_DIR}/tmp/deploy/images/%{DOMU_MACHINE}/%{BUILD_TARGET_DOMU}-%{DOMU_MACHINE}.ext4"
 
   ENABLE_ZEPHYR:
     desc: "Build Zephyr as guest domain"

--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -12,6 +12,8 @@ variables:
   ANDROID_KERNEL_DIR: "android_kernel"
   DOMA_DIR: "android"
   DOMZ_DIR: "zephyr"
+  BUILD_TARGET_DOMD: "core-image-weston"
+  BUILD_TARGET_DOMU: "core-image-weston"
   XT_DOMD_DTB_NAME: "%{SOC_FAMILY}-%{DOMD_MACHINE}-domd.dtb"
   XT_DOMU_DTB_NAME: "salvator-generic-domu.dtb"
   XT_DOMA_DTB_NAME: ""
@@ -233,7 +235,7 @@ components:
         - [PREFERRED_VERSION_xen, "4.19.0+git%"]
         - [PREFERRED_VERSION_xen-tools, "4.19.0+git%"]
 
-      build_target: core-image-weston
+      build_target: "%{BUILD_TARGET_DOMD}"
       layers:
         - "../meta-renesas/meta-rcar-gen3"
         - "../meta-virtualization"
@@ -257,7 +259,7 @@ components:
         - "tmp/deploy/images/%{DOMD_MACHINE}/xen-%{DOMD_MACHINE}.uImage"
         - "tmp/deploy/images/%{DOMD_MACHINE}/xenpolicy-%{DOMD_MACHINE}"
         - "tmp/deploy/images/%{DOMD_MACHINE}/%{XT_XEN_DTB_NAME}"
-        - "tmp/deploy/images/%{DOMD_MACHINE}/core-image-weston-%{DOMD_MACHINE}.ext4"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/%{BUILD_TARGET_DOMD}-%{DOMD_MACHINE}.ext4"
 
   domu:
     build-dir: "%{YOCTOS_WORK_DIR}"
@@ -290,10 +292,10 @@ components:
         - "../meta-xt-rcar/meta-xt-rcar-domu"
         - "../meta-xt-prod-devel-rcar/meta-xt-domx-gen3"
         - "../meta-xt-prod-devel-rcar/meta-xt-domu-gen3"
-      build_target: core-image-weston
+      build_target: "%{BUILD_TARGET_DOMU}"
       target_images:
         - "tmp/deploy/images/%{DOMU_MACHINE}/Image"
-        - "tmp/deploy/images/%{DOMU_MACHINE}/core-image-weston-%{DOMU_MACHINE}.ext4"
+        - "tmp/deploy/images/%{DOMU_MACHINE}/%{BUILD_TARGET_DOMU}-%{DOMU_MACHINE}.ext4"
 
   doma_kernel:
     build-dir: "%{ANDROID_KERNEL_DIR}"
@@ -394,7 +396,7 @@ images:
       domd_rootfs:
         gpt_type: B921B045-1DF0-41C3-AF44-4C6F280D3FAE # Linux aarch64 root
         type: raw_image
-        image_path: "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{DOMD_MACHINE}/core-image-weston-%{DOMD_MACHINE}.ext4"
+        image_path: "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{DOMD_MACHINE}/%{BUILD_TARGET_DOMD}-%{DOMD_MACHINE}.ext4"
 
 parameters:
   # Machines
@@ -596,7 +598,7 @@ parameters:
               domu-rootfs:
                 type: raw_image
                 gpt_type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4 # Linux filesystem data
-                image_path: "%{YOCTOS_WORK_DIR}/%{DOMU_BUILD_DIR}/tmp/deploy/images/%{DOMU_MACHINE}/core-image-weston-%{DOMU_MACHINE}.ext4"
+                image_path: "%{YOCTOS_WORK_DIR}/%{DOMU_BUILD_DIR}/tmp/deploy/images/%{DOMU_MACHINE}/%{BUILD_TARGET_DOMU}-%{DOMU_MACHINE}.ext4"
 
   ENABLE_ZEPHYR:
     desc: "Build Zephyr as guest domain"


### PR DESCRIPTION
Variables BUILD_TARGET_DOMD and BUILD_TARGET_DOMU are used to specify build target for corresponding domains and their build products.
This change allows to switch build target in further commits.