### PR TITLE
virtio: dom0: add 'no GPU, no display' config for DomU

### DIFF
--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domu/domu.bbappend
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domu/domu.bbappend
@@ -6,6 +6,7 @@ SRC_URI += "\
     file://domu-pvcamera.cfg \
     file://virtio.cfg \
     file://domu-vdevices-virtio.cfg \
+    file://domu-vdevices-virtio-nogsx.cfg \
     file://domu-set-root \
     file://domu-set-root.conf \
     file://domu-set-root-virtio.conf \
@@ -37,7 +38,11 @@ do_install:append() {
 
     if ${@bb.utils.contains('DISTRO_FEATURES', 'enable_virtio', 'true', 'false', d)}; then
         cat ${WORKDIR}/virtio.cfg >> ${CFG_FILE}
-        cat ${WORKDIR}/domu-vdevices-virtio.cfg >> ${CFG_FILE}
+        if ${@bb.utils.contains('MACHINE_FEATURES', 'gsx', 'true', 'false', d)}; then
+            cat ${WORKDIR}/domu-vdevices-virtio.cfg >> ${CFG_FILE}
+        else
+            cat ${WORKDIR}/domu-vdevices-virtio-nogsx.cfg >> ${CFG_FILE}
+        fi
     else
         cat ${WORKDIR}/domu-vdevices.cfg >> ${CFG_FILE}
         cat ${WORKDIR}/pvr-${XT_DOMU_CONFIG_NAME} >> ${CFG_FILE}

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domu/files/domu-vdevices-virtio-nogsx.cfg
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domu/files/domu-vdevices-virtio-nogsx.cfg
@@ -1,0 +1,25 @@
+# =====================================================================
+# DomU virtio virtual devices
+# =====================================================================
+
+virtio=[
+'backend=DomD, type=virtio,device, transport=pci, bdf=0000:00:01.0, grant_usage=1, backend_type=qemu',
+'backend=DomD, type=virtio,device, transport=pci, bdf=0000:00:02.0, grant_usage=1, backend_type=qemu',
+'backend=DomD, type=virtio,device, transport=pci, bdf=0000:00:03.0, grant_usage=1, backend_type=qemu',
+'backend=DomD, type=virtio,device, transport=pci, bdf=0000:00:06.0, grant_usage=1, backend_type=qemu',
+[VIRTIO_DRIVE_CONFIGURATION]
+]
+
+device_model_args=[
+'-device', 'virtio-net-pci,disable-legacy=on,iommu_platform=on,bus=pcie.0,addr=1,romfile=,id=nic0,netdev=net0,mac=08:00:27:ff:cb:cf',
+'-netdev', 'type=tap,id=net0,ifname=vif-emu,br=xenbr0,script=no,downscript=no,vhost=on',
+'-device', 'virtio-keyboard-pci,disable-legacy=on,iommu_platform=on,bus=pcie.0,addr=2',
+'-audiodev', 'alsa,id=snd0,out.dev=default',
+'-device', 'virtio-snd-pci,audiodev=snd0,disable-legacy=on,iommu_platform=on,bus=pcie.0,addr=3',
+'-display', 'none',
+'-device', 'vhost-vsock-pci,guest-cid=3,disable-legacy=on,iommu_platform=on,bus=pcie.0,addr=6',
+'-d', 'guest_errors',
+'-monitor', 'telnet:127.0.0.1:1234,server,nowait',
+'-global', 'virtio-mmio.force-legacy=false',
+[QEMU_DRIVE_CONFIGURATION]
+]

--- a/prod-devel-rcar-virtio.yaml
+++ b/prod-devel-rcar-virtio.yaml
@@ -733,6 +733,12 @@ parameters:
           # Directory containing ${SOC_NAME}_linux_gsx_binaries_gles.tar.gz
           XT_PREBUILT_GSX_DIR: "${TOPDIR}/../../../prebuilt_gsx"
         components:
+          dom0:
+            builder:
+              conf:
+                # this machine feature is required to select proper
+                # configuration for DomU
+                - [MACHINE_FEATURES:append, " gsx"]
           domd:
             builder:
               conf:
@@ -752,6 +758,12 @@ parameters:
       overrides:
         # for the linux
         components:
+          dom0:
+            builder:
+              conf:
+                # this machine feature is required to select proper
+                # configuration for DomU
+                - [MACHINE_FEATURES:append, " gsx"]
           domd:
             sources:
               - *GFX_SOURCES


### PR DESCRIPTION
This commit adds possibility to use DomU without
any display and 3D GSX.
This is part of the preparation for the console-only set up.