### PR TITLE
yaml: change meta-xt-vhost repository protocol

### DIFF
--- a/prod-devel-rcar-virtio.yaml
+++ b/prod-devel-rcar-virtio.yaml
@@ -221,7 +221,7 @@ components:
         url: https://git.yoctoproject.org/meta-selinux
         rev: kirkstone
       - type: git
-        url: ssh://git@github.com/xen-troops/meta-xt-vhost.git
+        url: https://github.com/xen-troops/meta-xt-vhost.git
         rev: main
     builder:
       type: yocto


### PR DESCRIPTION
Switch to using HTTPS instead of SSH. This will allow users without GitHub registration to clone the repository.