### PR TITLE
xen: define SRCREV

### DIFF
--- a/meta-xt-domx-gen3/recipes-extended/xen/xen-source.inc
+++ b/meta-xt-domx-gen3/recipes-extended/xen/xen-source.inc
@@ -2,3 +2,4 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d1a1e216f80b6d8da95fec897d0dbec9"
 
 XEN_URL = "git://github.com/xen-troops/xen.git;protocol=https;branch=xen-4.19-xt0.1"
 XEN_REL = "4.19"
+XEN_REV = "${AUTOREV}"


### PR DESCRIPTION
If the product overrides XEN_REL, it should override XEN_REV as well, because overridden branch may not contain revision defined in base layers.
So, considering that this is prod-devel, we set XEN_REV to ${AUTOREV}.