### PR TITLE
domd: get rid of meta-xt-vhost

### DIFF
--- a/prod-devel-rcar-virtio.yaml
+++ b/prod-devel-rcar-virtio.yaml
@@ -1,4 +1,4 @@
-desc: "Xen-Troops development setup for Renesas RCAR Gen3 hardware (depends on the private meta-xt-vhost, see README.md)"
+desc: "Xen-Troops development setup for Renesas RCAR Gen3 hardware"
 min_ver: "0.20"
 
 variables:
@@ -220,9 +220,6 @@ components:
       - type: git
         url: https://git.yoctoproject.org/meta-selinux
         rev: kirkstone
-      - type: git
-        url: https://github.com/xen-troops/meta-xt-vhost.git
-        rev: main
     builder:
       type: yocto
       work_dir: "%{DOMD_BUILD_DIR}"
@@ -274,7 +271,6 @@ components:
         - "../meta-xt-prod-devel-rcar/meta-xt-domx-gen3"
         - "../meta-xt-prod-devel-rcar/meta-xt-prod-devel-rcar-driver-domain"
         - "../meta-xt-prod-devel-rcar/meta-xt-domd-gen3"
-        - "../meta-xt-vhost"
       target_images:
         - "tmp/deploy/images/%{DOMD_MACHINE}/Image"
         - "tmp/deploy/images/%{DOMD_MACHINE}/xen-%{DOMD_MACHINE}.uImage"


### PR DESCRIPTION
meta-xt-vhost contains only kernel patches and its content is merged into kernel on xen-troops branch that is used by the virtio setup. So can remove the meta-xt-vhost repo.