### PR TITLE
domd: domu: wrap lisot by DISTRO_FEATURES

### DIFF
--- a/meta-xt-domd-gen3/recipes-tools/images/common_install.inc
+++ b/meta-xt-domd-gen3/recipes-tools/images/common_install.inc
@@ -1,5 +1,5 @@
 IMAGE_INSTALL:append = " \
-    lisot \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'enable_virtio', 'lisot', '', d)} \
     expect \
     ltrace \
     evtest \

--- a/meta-xt-domu-gen3/recipes-tools/images/common_install.inc
+++ b/meta-xt-domu-gen3/recipes-tools/images/common_install.inc
@@ -1,7 +1,7 @@
 IMAGE_INSTALL:append = " \
     pciutils \
     iperf3 \
-    lisot \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'enable_virtio', 'lisot', '', d)} \
     expect \
     ltrace \
     evtest \


### PR DESCRIPTION
Lisot is the tools for virtio setup, so we should add it to the image only when 'enable_virtio' is in the DISTRO_FEATURES.