### PR TITLE
Change URL for the lisot sources

### DIFF
--- a/meta-xt-domx-gen3/recipes-tools/lisot/lisot.bb
+++ b/meta-xt-domx-gen3/recipes-tools/lisot/lisot.bb
@@ -6,7 +6,7 @@ PR = "r0"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/dterletskiy/lisot.git;protocol=https;branch=main \
+    git://github.com/xen-troops/lisot.git;protocol=https;branch=main \
 "
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"


### PR DESCRIPTION
We have moved the lisot repo to the xen-troops organization. So this commit updates SRC_URI accordingly.