### PR TITLE
dom0: wrap usage of the XT_DOMU_CONFIG_NAME

### DIFF
--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domu/domu.bbappend
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domu/domu.bbappend
@@ -12,8 +12,12 @@ SRC_URI += "\
     file://domu-set-root-virtio.conf \
     ${@bb.utils.contains('DISTRO_FEATURES', 'sndbe', 'file://sndbe-backend.conf', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'displbe', 'file://displbe-backend.conf', '', d)} \
-    file://pvr-${XT_DOMU_CONFIG_NAME} \
 "
+
+python () {
+    if d.getVar('XT_DOMU_CONFIG_NAME'):
+        d.appendVar('SRC_URI', ' file://pvr-${XT_DOMU_CONFIG_NAME}')
+}
 
 FILES:${PN} += " \
     ${libdir}/xen/bin/domu-set-root \


### PR DESCRIPTION
The variable `XT_DOMU_CONFIG_NAME` is not defined if domu is not used. In such a case, yocto fails during the parsing of the `domu.bbappend` file due to an attempt to calculate the checksum of the non-existing file `pvr-${XT_DOMU_CONFIG_NAME}`.

Fixes: 4c277f4f00095bb6875a1d82b51c63ef74704bbd ("dom-0: update xen config for dom-u")