### PR TITLE
Remove not needed meta-aos-tune layer

### DIFF
--- a/prod-devel-rcar-virtio.yaml
+++ b/prod-devel-rcar-virtio.yaml
@@ -711,9 +711,9 @@ parameters:
             builder:
               layers:
                 - "../meta-aos"
-                - "../meta-xt-prod-devel-rcar/meta-aos-tune"
               conf:
-                - [AOS_VIS_PLUGINS, "telemetryemulatoradapter"]
+                - [AOS_VIS_PLUGINS, "storageadapter"]
+                - [AOS_VIS_DATA_PROVIDER, "telemetryemulatoradapter"]
                 - [DISTRO_FEATURES:append, " vis"]
           doma:
             builder:


### PR DESCRIPTION
This layer doesn't exist and was skipped during the removal.

Fixes: 559c0d6c2f30 ("meta-aos-tune: remove unneeded meta-aos-tune layer")

---
The change was tested by the build. 