### PR TITLE
docker: change the mounting of the .gitconfig

### DIFF
--- a/doc/run_docker.sh
+++ b/doc/run_docker.sh
@@ -57,6 +57,6 @@ echo "DOCKER_IMAGE_NAME : $DOCKER_IMAGE_NAME"
 docker run \
 	--network=host \
 	-v "$HOME"/.ssh:/home/builder/.ssh \
-	-v "$HOME"/.gitconfig:/home/builder/.gitconfig \
+	--mount type=bind,source="$HOME"/.gitconfig,target=/home/builder/.gitconfig \
 	-v "${WORKSPACE}":/home/builder/workspace \
 	-ti --rm "$DOCKER_IMAGE_NAME"


### PR DESCRIPTION
Option `-v` creates a directory, if specified host file was not found. As result if `run_docker.sh` will be used on the clean host without initialized `${HOME}/.gitconfig`, script will create a folder with the same name, resulting in mess.

But using of the `--mount type=bind,...` without the required file will result in error message that file doesn't exist. Thuis allowing user properly detect and solve an issue.