### PR TITLE
doma: update kernel revision to correct

### DIFF
--- a/prod-devel-rcar-virtio.yaml
+++ b/prod-devel-rcar-virtio.yaml
@@ -313,7 +313,7 @@ components:
     sources:
       - type: repo
         url: https://github.com/xen-troops/android_kernel_manifest.git
-        rev: "88fde711b5c2c379cbdb361c63f7653bd6352aee" # common-android14-6.1-xenvm-trout-main
+        rev: "f068d73e6ba7e8b7406d65e0d16419b660eb1dca" # common-android14-6.1-xenvm-trout-main
         manifest: default.xml
         depth: 1
         groups: "%{XT_DOMA_SOURCE_GROUP}"


### PR DESCRIPTION
Fixes:0d95495bc197(doma: switch to Android 15)
The 0d95495bc197 commit points to the Android kernel manifest, which contains a mistake.