### PR TITLE
doc: add info regarding bootm_size

### DIFF
--- a/doc/u-boot-env.md
+++ b/doc/u-boot-env.md
@@ -18,6 +18,7 @@ Boot device is selected by setting 'bootcmd' variable. E.g. `setenv bootcmd run 
 ## Common settings, recommended for any boot device
 ```
 setenv bootargs
+setenv bootm_size
 setenv ethact ravb
 setenv ipaddr 192.168.1.10
 setenv serverip 192.168.1.100


### PR DESCRIPTION
The u-boot variable `bootm_size` has to be empty during the boot.


Suggested-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>