### PR TITLE
yaml: update path and  file names in "pack-ipl" component 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   - [Fetching](#fetching)
   - [Building](#building)
   - [Build products](#build-products)
+  - [Pack-IPL: Packaging Boot Artifacts](#pack-ipl-packaging-boot-artifacts)
   - [Building with prebuilt graphics for DomD+DomU](#building-with-prebuilt-graphics-for-domddomu)
   - [Building with prebuilt graphics and Android guest](#building-with-prebuilt-graphics-and-android-guest)
     - [Creating SD card image](#creating-sd-card-image)
@@ -178,6 +179,22 @@ For `moulin prod-devel-rcar-virtio.yaml`:
 | android_kernel/   # Android kernel
 | android/          # Android
 ```
+
+## Pack-IPL: Packaging Boot Artifacts
+
+There is a possibility of quickly packaging boot artifacts. These artifacts are generated during the `domd` build process and are used for flashing the board.
+
+The product provides two options for packaging artifacts:
+- Pack-ipl – used for all machines described in the product YAML file except `salvator-xs-m3-2x4g`. Run with the command:
+```
+ninja pack-ipl
+```
+- Pack-ipl-m3 – used only for the `salvator-xs-m3-2x4g` machine, because it is specific and uses its own `-2x4g` memory suffix. Run with the command:
+```
+ninja pack-ipl-m3
+```
+Note: To generate artifacts, the `domd` component must be built. If it has not been built before, its build will start automatically.
+After successful execution, a `*.tar.bz2` archive will be created in the project directory. This archive will contain all the required artifacts for the selected board.
 
 ## Building with prebuilt graphics for DomD+DomU
 

--- a/layers/meta-xt-domd-gen3/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_git.bbappend
+++ b/layers/meta-xt-domd-gen3/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_git.bbappend
@@ -1,0 +1,12 @@
+# Reason for this recipe:
+# -- The "pack-ipl" component requires "bootparam_sa0.bin" and "cert_header_sa6.bin"
+# to have the "-4x2g" suffix.
+# -- On "h3ulcb-4x2g-kf" this comes from extra layers, but for the other machines in the YAML the
+# suffix was missing.
+# -- This recipe adds the required suffix (via ${EXTRA_ATFW_CONF}) so filenames are consistent
+# and "pack-ipl" works correctly across all machines.
+
+do_ipl_opt_deploy:append () {
+    install -m 0644 ${S}/tools/renesas/rcar_layout_create/bootparam_sa0.bin ${DEPLOY_DIR_IMAGE}/bootparam_sa0-${EXTRA_ATFW_CONF}.bin
+    install -m 0644 ${S}/tools/renesas/rcar_layout_create/cert_header_sa6.bin ${DEPLOY_DIR_IMAGE}/cert_header_sa6-${EXTRA_ATFW_CONF}.bin
+}

--- a/prod-devel-rcar-virtio.yaml
+++ b/prod-devel-rcar-virtio.yaml
@@ -389,6 +389,28 @@ components:
         - "u-boot-elf-%{DOMD_MACHINE}.srec"
         - "u-boot-%{DOMD_MACHINE}.bin"
 
+  pack-ipl-m3:
+    build-dir: "."
+    builder:
+      type: archive
+      base_dir: "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{DOMD_MACHINE}/"
+      name: "ipl-%{DOMD_MACHINE}s-m3-2x4g.tar.bz2"
+      items:
+        - "bl2-%{DOMD_MACHINE}.bin"
+        - "bl2-%{DOMD_MACHINE}.srec"
+        - "bl31-%{DOMD_MACHINE}.bin"
+        - "bl31-%{DOMD_MACHINE}.srec"
+        - "bootparam_sa0.bin"
+        - "bootparam_sa0.srec"
+        - "cert_header_sa6.bin"
+        - "cert_header_sa6.srec"
+        - "cert_header_sa6_emmc.bin"
+        - "cert_header_sa6_emmc.srec"
+        - "optee/tee-raw.bin"
+        - "optee/tee-%{DOMD_MACHINE}.srec"
+        - "u-boot-elf-%{DOMD_MACHINE}.srec"
+        - "u-boot-%{DOMD_MACHINE}.bin"
+
 images:
   full:
     type: gpt
@@ -425,6 +447,19 @@ parameters:
           XT_OP_TEE_FLAVOUR: "salvator_m3_2x4g"
           XT_DOMD_DTB_NAME: "r8a77961-salvator-xs-2x4g-domd.dtb"
           XT_XEN_DTB_NAME: "r8a77961-salvator-xs-2x4g-xen.dtb"
+        components:
+          domd:
+            builder:
+              target_images:
+                # These dependencies are required for correct operation of "pack-ipl-m3" when "domd" has not yet been built.
+                - "tmp/deploy/images/%{DOMD_MACHINE}/bl2-%{DOMD_MACHINE}.bin"
+                - "tmp/deploy/images/%{DOMD_MACHINE}/bl2-%{DOMD_MACHINE}.srec"
+                - "tmp/deploy/images/%{DOMD_MACHINE}/bl31-%{DOMD_MACHINE}.bin"
+                - "tmp/deploy/images/%{DOMD_MACHINE}/bl31-%{DOMD_MACHINE}.srec"
+                - "tmp/deploy/images/%{DOMD_MACHINE}/bootparam_sa0.bin"
+                - "tmp/deploy/images/%{DOMD_MACHINE}/bootparam_sa0.srec"
+                - "tmp/deploy/images/%{DOMD_MACHINE}/cert_header_sa6.bin"
+                - "tmp/deploy/images/%{DOMD_MACHINE}/cert_header_sa6.srec"
     salvator-xs-h3-4x2g:
       overrides:
         variables:

--- a/prod-devel-rcar-virtio.yaml
+++ b/prod-devel-rcar-virtio.yaml
@@ -262,6 +262,22 @@ components:
         - "tmp/deploy/images/%{DOMD_MACHINE}/%{XT_XEN_DTB_NAME}"
         - "tmp/deploy/images/%{DOMD_MACHINE}/%{BUILD_TARGET_DOMD}-%{DOMD_MACHINE}.ext4"
 
+        # These dependencies are required for correct operation of "pack-ipl" when "domd" has not yet been built.
+        - "tmp/deploy/images/%{DOMD_MACHINE}/bl2-%{DOMD_MACHINE}-4x2g.bin"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/bl2-%{DOMD_MACHINE}-4x2g.srec"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/bl31-%{DOMD_MACHINE}-4x2g.bin"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/bl31-%{DOMD_MACHINE}-4x2g.srec"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/bootparam_sa0-4x2g.bin"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/bootparam_sa0-4x2g.srec"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/cert_header_sa6-4x2g.bin"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/cert_header_sa6-4x2g.srec"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/cert_header_sa6_emmc.bin"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/cert_header_sa6_emmc.srec"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/optee/tee-raw.bin"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/optee/tee-%{DOMD_MACHINE}.srec"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/u-boot-elf-%{DOMD_MACHINE}.srec"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/u-boot-%{DOMD_MACHINE}.bin"
+
   domu:
     build-dir: "%{YOCTOS_WORK_DIR}"
     sources:

--- a/prod-devel-rcar-virtio.yaml
+++ b/prod-devel-rcar-virtio.yaml
@@ -355,7 +355,7 @@ components:
     build-dir: "."
     builder:
       type: archive
-      base_dir: "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{DOMD_MACHINE}/firmware/"
+      base_dir: "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{DOMD_MACHINE}/"
       name: "ipl-%{DOMD_MACHINE}.tar.bz2"
       items:
         - "bl2-%{DOMD_MACHINE}-4x2g.bin"
@@ -368,8 +368,8 @@ components:
         - "cert_header_sa6-4x2g.srec"
         - "cert_header_sa6_emmc.bin"
         - "cert_header_sa6_emmc.srec"
-        - "../optee/tee-raw.bin"
-        - "../optee/tee-%{DOMD_MACHINE}.srec"
+        - "optee/tee-raw.bin"
+        - "optee/tee-%{DOMD_MACHINE}.srec"
         - "u-boot-elf-%{DOMD_MACHINE}.srec"
         - "u-boot-%{DOMD_MACHINE}.bin"
 

--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -237,6 +237,22 @@ components:
         - "tmp/deploy/images/%{DOMD_MACHINE}/%{XT_XEN_DTB_NAME}"
         - "tmp/deploy/images/%{DOMD_MACHINE}/%{BUILD_TARGET_DOMD}-%{DOMD_MACHINE}.ext4"
 
+        # These dependencies are required for correct operation of "pack-ipl" when "domd" has not yet been built.
+        - "tmp/deploy/images/%{DOMD_MACHINE}/bl2-%{DOMD_MACHINE}-4x2g.bin"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/bl2-%{DOMD_MACHINE}-4x2g.srec"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/bl31-%{DOMD_MACHINE}-4x2g.bin"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/bl31-%{DOMD_MACHINE}-4x2g.srec"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/bootparam_sa0-4x2g.bin"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/bootparam_sa0-4x2g.srec"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/cert_header_sa6-4x2g.bin"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/cert_header_sa6-4x2g.srec"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/cert_header_sa6_emmc.bin"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/cert_header_sa6_emmc.srec"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/optee/tee-raw.bin"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/optee/tee-%{DOMD_MACHINE}.srec"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/u-boot-elf-%{DOMD_MACHINE}.srec"
+        - "tmp/deploy/images/%{DOMD_MACHINE}/u-boot-%{DOMD_MACHINE}.bin"
+
   domu:
     build-dir: "%{YOCTOS_WORK_DIR}"
     sources:

--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -311,6 +311,28 @@ components:
         - "u-boot-elf-%{DOMD_MACHINE}.srec"
         - "u-boot-%{DOMD_MACHINE}.bin"
 
+  pack-ipl-m3:
+    build-dir: "."
+    builder:
+      type: archive
+      base_dir: "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{DOMD_MACHINE}/"
+      name: "ipl-%{DOMD_MACHINE}s-m3-2x4g.tar.bz2"
+      items:
+        - "bl2-%{DOMD_MACHINE}.bin"
+        - "bl2-%{DOMD_MACHINE}.srec"
+        - "bl31-%{DOMD_MACHINE}.bin"
+        - "bl31-%{DOMD_MACHINE}.srec"
+        - "bootparam_sa0.bin"
+        - "bootparam_sa0.srec"
+        - "cert_header_sa6.bin"
+        - "cert_header_sa6.srec"
+        - "cert_header_sa6_emmc.bin"
+        - "cert_header_sa6_emmc.srec"
+        - "optee/tee-raw.bin"
+        - "optee/tee-%{DOMD_MACHINE}.srec"
+        - "u-boot-elf-%{DOMD_MACHINE}.srec"
+        - "u-boot-%{DOMD_MACHINE}.bin"
+
 images:
   full:
     type: gpt
@@ -346,6 +368,19 @@ parameters:
           XT_OP_TEE_FLAVOUR: "salvator_m3_2x4g"
           XT_DOMD_DTB_NAME: "r8a77961-salvator-xs-2x4g-domd.dtb"
           XT_XEN_DTB_NAME: "r8a77961-salvator-xs-2x4g-xen.dtb"
+        components:
+          domd:
+            builder:
+              target_images:
+                # These dependencies are required for correct operation of "pack-ipl-m3" when "domd" has not yet been built.
+                - "tmp/deploy/images/%{DOMD_MACHINE}/bl2-%{DOMD_MACHINE}.bin"
+                - "tmp/deploy/images/%{DOMD_MACHINE}/bl2-%{DOMD_MACHINE}.srec"
+                - "tmp/deploy/images/%{DOMD_MACHINE}/bl31-%{DOMD_MACHINE}.bin"
+                - "tmp/deploy/images/%{DOMD_MACHINE}/bl31-%{DOMD_MACHINE}.srec"
+                - "tmp/deploy/images/%{DOMD_MACHINE}/bootparam_sa0.bin"
+                - "tmp/deploy/images/%{DOMD_MACHINE}/bootparam_sa0.srec"
+                - "tmp/deploy/images/%{DOMD_MACHINE}/cert_header_sa6.bin"
+                - "tmp/deploy/images/%{DOMD_MACHINE}/cert_header_sa6.srec"
     salvator-xs-h3-4x2g:
       overrides:
         variables:

--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -277,7 +277,7 @@ components:
     build-dir: "."
     builder:
       type: archive
-      base_dir: "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{DOMD_MACHINE}/firmware/"
+      base_dir: "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{DOMD_MACHINE}/"
       name: "ipl-%{DOMD_MACHINE}.tar.bz2"
       items:
         - "bl2-%{DOMD_MACHINE}-4x2g.bin"
@@ -290,8 +290,8 @@ components:
         - "cert_header_sa6-4x2g.srec"
         - "cert_header_sa6_emmc.bin"
         - "cert_header_sa6_emmc.srec"
-        - "../optee/tee-raw.bin"
-        - "../optee/tee-%{DOMD_MACHINE}.srec"
+        - "optee/tee-raw.bin"
+        - "optee/tee-%{DOMD_MACHINE}.srec"
         - "u-boot-elf-%{DOMD_MACHINE}.srec"
         - "u-boot-%{DOMD_MACHINE}.bin"
 


### PR DESCRIPTION
After migration to Kirkstone, this change stopped working:
https://github.com/xen-troops/meta-xt-rcar/commit/
c5e7840ae99f4e6d1e8c170bed54244231d31d0b

It was decided to drop usage of the "firmware" directory,
following the approach used in other Xen Troops projects.

Also, Updated "bootparam_sa0.bin" and "cert_header_sa6.bin" naming to allow
the "pack-ipl" component to work not only for "h3ulcb-4x2g-kf" machine
but also for all other machines defined in YAML files.

Tested for  "h3ulcb-4x2g-kf" and "salvator-x-h3-4x2g" machines.